### PR TITLE
Fix inconsistent dtype for reward in MemoryChain environment

### DIFF
--- a/gymnax/environments/bsuite/memory_chain.py
+++ b/gymnax/environments/bsuite/memory_chain.py
@@ -44,7 +44,7 @@ class MemoryChain(environment.Environment):
         obs = self.get_obs(state, params)
 
         # State smaller than mem length = 0 reward
-        reward = 0
+        reward = 0.0
         mem_not_full = state.time < params.memory_length
         correct_action = action == state.context[state.query]
         mem_correct = jnp.logical_and(1 - mem_not_full, correct_action)


### PR DESCRIPTION
Hey Robert,
I tried to `jax.lax.scan` over the bsuite-MemoryChain environment and noticed that the reward returned by this env is an `int32` instead of a `float32` as for the other environments. Was this on purpose? If not here would be the minimal fix.

Best,
Simon