### PR TITLE
[Feature] GymnaxToBrax conversion wrapper

### DIFF
--- a/gymnax/environments/conversions/brax.py
+++ b/gymnax/environments/conversions/brax.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, Union, Optional
+from brax.envs.env import Env
+import jax
+import chex
+from ..environment import Environment, EnvState, EnvParams
+from flax.struct import dataclass, field
+
+
+@dataclass
+class State:  # Lookalike for brax.envs.env.State
+    qp: EnvState  # Brax QP is roughly equivalent to our EnvState
+    obs: Any  # depends on environment
+    reward: float
+    done: bool
+    metrics: Dict[str, Union[chex.Array, chex.Scalar]] = field(default_factory=dict)
+    info: Dict[str, Any] = field(default_factory=dict)
+
+
+class GymnaxToBraxWrapper(Env):
+    def __init__(self, env: Environment):
+        """Wrap Gymnax environment as Brax environment
+
+        Primarily useful for including obs, reward, and done as part of state.
+        Compatible with all brax wrappers, but AutoResetWrapper is redundant since Gymnax environments
+        already reset state.
+
+        Args:
+            env: Gymnax environment instance
+        """
+        super().__init__('')
+        self.env = env
+
+    def reset(self, rng: chex.PRNGKey, params: Optional[EnvParams] = None) -> State:
+        """Reset, return brax State. Save rng and params in info field for step"""
+        if params is None: params = self.env.default_params
+        obs, env_state = self.env.reset(rng, params)
+        return State(env_state, obs, 0., False, {}, {'_rng': jax.random.split(rng)[0], '_env_params': params})
+
+    def step(self, state: State, action: Union[chex.Scalar, chex.Array], params: Optional[EnvParams] = None) -> State:
+        """Step, return brax State. Update stored rng and params (if provided) in info field"""
+        rng, step_rng = jax.random.split(state.info['_rng'])
+        if params is None: params = self.env.default_params
+        state.info.update(_rng=rng, _env_params=params)
+        o, env_state, r, d, info = self.env.step(step_rng, state.qp, action, params)
+        return state.replace(qp=env_state, obs=o, reward=r, done=d)
+
+    def action_size(self) -> int:
+        """DEFAULT size of action vector expected by step. Can't pass params to property"""
+        a_space = self.env.action_space(self.env.default_params)
+        example_a = a_space.sample(jax.random.PRNGKey(0))
+        return len(jax.tree_util.tree_flatten(example_a)[0])

--- a/gymnax/environments/conversions/brax.py
+++ b/gymnax/environments/conversions/brax.py
@@ -1,5 +1,9 @@
 from typing import Any, Dict, Union, Optional
-from brax.envs.env import Env
+
+try:
+    from brax.envs.env import Env
+except ImportError:
+    raise ImportError("You need to install `brax` to use the brax wrapper.")
 import jax
 import chex
 from ..environment import Environment, EnvState, EnvParams

--- a/gymnax/environments/conversions/brax.py
+++ b/gymnax/environments/conversions/brax.py
@@ -27,19 +27,33 @@ class GymnaxToBraxWrapper(Env):
         Args:
             env: Gymnax environment instance
         """
-        super().__init__('')
+        super().__init__("")
         self.env = env
 
     def reset(self, rng: chex.PRNGKey, params: Optional[EnvParams] = None) -> State:
         """Reset, return brax State. Save rng and params in info field for step"""
-        if params is None: params = self.env.default_params
+        if params is None:
+            params = self.env.default_params
         obs, env_state = self.env.reset(rng, params)
-        return State(env_state, obs, 0., False, {}, {'_rng': jax.random.split(rng)[0], '_env_params': params})
+        return State(
+            env_state,
+            obs,
+            0.0,
+            False,
+            {},
+            {"_rng": jax.random.split(rng)[0], "_env_params": params},
+        )
 
-    def step(self, state: State, action: Union[chex.Scalar, chex.Array], params: Optional[EnvParams] = None) -> State:
+    def step(
+        self,
+        state: State,
+        action: Union[chex.Scalar, chex.Array],
+        params: Optional[EnvParams] = None,
+    ) -> State:
         """Step, return brax State. Update stored rng and params (if provided) in info field"""
-        rng, step_rng = jax.random.split(state.info['_rng'])
-        if params is None: params = self.env.default_params
+        rng, step_rng = jax.random.split(state.info["_rng"])
+        if params is None:
+            params = self.env.default_params
         state.info.update(_rng=rng, _env_params=params)
         o, env_state, r, d, info = self.env.step(step_rng, state.qp, action, params)
         return state.replace(qp=env_state, obs=o, reward=r, done=d)

--- a/gymnax/environments/conversions/gym.py
+++ b/gymnax/environments/conversions/gym.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from typing import Optional, Tuple, Union, List
 
 import chex
@@ -28,10 +27,10 @@ class GymnaxToGymWrapper(gym.Env):
         super().__init__()
         self._env = deepcopy(env)
         self.env_params = params if params is not None else env.default_params
-        self.metadata |= {
+        self.metadata.update({
             "name": env.name,
             "render_modes": ["human", "rgb_array"] if hasattr(env, "render") else [],
-        }
+        })
         self.rng: chex.PRNGKey = jax.random.PRNGKey(0)  # Placeholder
         self._seed(seed)
         _, self.env_state = self._env.reset(self.rng, self.env_params)

--- a/gymnax/environments/conversions/gym.py
+++ b/gymnax/environments/conversions/gym.py
@@ -6,8 +6,8 @@ import gym
 import jax.random
 from gym.core import ActType, ObsType, RenderFrame
 from gym.vector.utils import batch_space
-from gymnax.environments.spaces import gymnax_space_to_gym_space
-from gymnax.environments.environment import Environment, EnvState, EnvParams
+from ..spaces import gymnax_space_to_gym_space
+from ..environment import Environment, EnvState, EnvParams
 from copy import deepcopy
 
 

--- a/gymnax/environments/conversions/gym.py
+++ b/gymnax/environments/conversions/gym.py
@@ -6,8 +6,8 @@ import gym
 import jax.random
 from gym.core import ActType, ObsType, RenderFrame
 from gym.vector.utils import batch_space
-from .spaces import gymnax_space_to_gym_space
-from .environment import Environment, EnvState, EnvParams
+from gymnax.environments.spaces import gymnax_space_to_gym_space
+from gymnax.environments.environment import Environment, EnvState, EnvParams
 from copy import deepcopy
 
 
@@ -68,7 +68,7 @@ class GymnaxToGymWrapper(gym.Env):
         seed: Optional[int] = None,
         return_info: bool = False,
         options: Optional[dict] = None,
-    ) -> Union[ObsType, Tuple[ObsType, dict]]:
+    ) -> Tuple[ObsType, dict]:
         """Reset environment, update parameters and seed if provided"""
         if seed is not None:
             self._seed(seed)
@@ -78,7 +78,7 @@ class GymnaxToGymWrapper(gym.Env):
             )  # Allow changing environment parameters on reset
         self.rng, reset_key = jax.random.split(self.rng)
         o, self.env_state = self._env.reset(reset_key, self.env_params)
-        return o
+        return o, {}
 
     def render(self, mode="human") -> Optional[Union[RenderFrame, List[RenderFrame]]]:
         """use underlying environment rendering if it exists, otherwise return None"""
@@ -152,7 +152,7 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
         seed: Optional[Union[int, List[int]]] = None,
         return_info: bool = False,
         options: Optional[dict] = None,
-    ):
+    ) -> Tuple[ObsType, dict]:
         """Reset environment, update parameters and seed if provided"""
         if seed is not None:
             self._seed(seed)
@@ -162,7 +162,7 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
             )  # Allow changing environment parameters on reset
         self.rng, reset_key = self._batched_rng_split(self.rng)  # Split all keys
         o, self.env_state = self._env.reset(reset_key, self.env_params)
-        return o
+        return o, {}
 
     def step(
         self, action: ActType

--- a/gymnax/environments/conversions/gym.py
+++ b/gymnax/environments/conversions/gym.py
@@ -166,9 +166,7 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
 
     def step(
         self, action: ActType
-    ) -> Union[
-        Tuple[ObsType, float, bool, bool, dict], Tuple[ObsType, float, bool, dict]
-    ]:
+    ) -> Tuple[ObsType, float, bool, bool, dict]:
         """Step environment, follow new step API"""
         self.rng, step_key = self._batched_rng_split(self.rng)
         o, self.env_state, r, d, info = self._env.step(

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -29,7 +29,7 @@ class Environment(object):
         state: EnvState,
         action: Union[int, float],
         params: Optional[EnvParams] = None,
-    ) -> Tuple[chex.Array, EnvState, float, bool]:
+    ) -> Tuple[chex.Array, EnvState, float, bool, dict]:
         """Performs step transitions in the environment."""
         # Use default env parameters if no others specified
         if params is None:

--- a/gymnax/environments/gym.py
+++ b/gymnax/environments/gym.py
@@ -82,7 +82,9 @@ class GymnaxToGymWrapper(gym.Env):
 
     def render(self, mode="human") -> Optional[Union[RenderFrame, List[RenderFrame]]]:
         """use underlying environment rendering if it exists, otherwise return None"""
-        return getattr(self._env, 'render', lambda x, y: None)(self.env_state, self.env_params)
+        return getattr(self._env, "render", lambda x, y: None)(
+            self.env_state, self.env_params
+        )
 
 
 class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
@@ -176,7 +178,6 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
 
     def render(self, mode="human") -> Optional[Union[RenderFrame, List[RenderFrame]]]:
         """use underlying environment rendering if it exists (for first environment), otherwise return None"""
-        return getattr(self._env, 'render', lambda x, y: None)(
-            jax.tree_map(lambda x: x[0], self.env_state),
-            self.env_params
+        return getattr(self._env, "render", lambda x, y: None)(
+            jax.tree_map(lambda x: x[0], self.env_state), self.env_params
         )

--- a/gymnax/environments/gym.py
+++ b/gymnax/environments/gym.py
@@ -1,0 +1,182 @@
+from functools import lru_cache
+from typing import Optional, Tuple, Union, List
+
+import chex
+import gym
+import jax.random
+from gym.core import ActType, ObsType, RenderFrame
+from gym.vector.utils import batch_space
+from .spaces import gymnax_space_to_gym_space
+from .environment import Environment, EnvState, EnvParams
+from copy import deepcopy
+
+
+class GymnaxToGymWrapper(gym.Env):
+    def __init__(
+        self,
+        env: Environment,
+        params: Optional[EnvParams] = None,
+        seed: Optional[int] = None,
+    ):
+        """Wrap Gymnax environment as OOP Gym environment
+
+        Args:
+            env: Gymnax Environment instance
+            params: If provided, gymnax EnvParams for environment (otherwise uses default)
+            seed: If provided, seed for JAX PRNG (otherwise picks 0)
+        """
+        super().__init__()
+        self._env = deepcopy(env)
+        self.env_params = params if params is not None else env.default_params
+        self.metadata |= {
+            "name": env.name,
+            "render_modes": ["human", "rgb_array"] if hasattr(env, "render") else [],
+        }
+        self.rng: chex.PRNGKey = jax.random.PRNGKey(0)  # Placeholder
+        self._seed(seed)
+        _, self.env_state = self._env.reset(self.rng, self.env_params)
+
+    @property
+    def action_space(self):
+        """Dynamically adjust action space depending on params"""
+        return gymnax_space_to_gym_space(self._env.action_space(self.env_params))
+
+    @property
+    def observation_space(self):
+        """Dynamically adjust state space depending on params"""
+        return gymnax_space_to_gym_space(self._env.observation_space(self.env_params))
+
+    def _seed(self, seed: Optional[int] = None):
+        """Set RNG seed (or use 0)"""
+        self.rng = jax.random.PRNGKey(seed or 0)
+
+    def step(
+        self, action: ActType
+    ) -> Union[
+        Tuple[ObsType, float, bool, bool, dict], Tuple[ObsType, float, bool, dict]
+    ]:
+        """Step environment, follow new step API"""
+        self.rng, step_key = jax.random.split(self.rng)
+        o, self.env_state, r, d, info = self._env.step(
+            step_key, self.env_state, action, self.env_params
+        )
+        return o, r, d, d, info
+
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        return_info: bool = False,
+        options: Optional[dict] = None,
+    ) -> Union[ObsType, Tuple[ObsType, dict]]:
+        """Reset environment, update parameters and seed if provided"""
+        if seed is not None:
+            self._seed(seed)
+        if options is not None:
+            self.env_params = options.get(
+                "env_params", self.env_params
+            )  # Allow changing environment parameters on reset
+        self.rng, reset_key = jax.random.split(self.rng)
+        o, self.env_state = self._env.reset(reset_key, self.env_params)
+        return o
+
+    def render(self, mode="human") -> Optional[Union[RenderFrame, List[RenderFrame]]]:
+        """use underlying environment rendering if it exists, otherwise return None"""
+        return getattr(self._env, 'render', lambda x, y: None)(self.env_state, self.env_params)
+
+
+class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
+    def __init__(
+        self,
+        env: Environment,
+        num_envs: int = 1,
+        params: Optional[EnvParams] = None,
+        seed: Optional[int] = None,
+    ):
+        """Wrap Gymnax environment as OOP Gym Vector Environment
+
+        Args:
+            env: Gymnax Environment instance
+            num_envs: Desired number of environments to run in parallel
+            params: If provided, gymnax EnvParams for environment (otherwise uses default)
+            seed: If provided, seed for JAX PRNG (otherwise picks 0)
+        """
+        self._env = deepcopy(env)
+        self.num_envs = num_envs
+        self.is_vector_env = True
+        self.new_step_api = True
+        self.closed = False
+        self.viewer = None
+        self.rng: chex.PRNGKey = jax.random.PRNGKey(0)  # Placeholder
+        self._seed(seed)
+        # Jit-of-vmap is faster than vmap-of-jit. Map over leading axis of all but env params
+        self._env.reset = jax.jit(jax.vmap(self._env.reset, in_axes=(0, None)))
+        self._env.step = jax.jit(jax.vmap(self._env.step, in_axes=(0, 0, 0, None)))
+        self.env_params = params if params is not None else env.default_params
+        _, self.env_state = self._env.reset(self.rng, self.env_params)  # Placeholder
+        self._batched_rng_split = jax.jit(
+            jax.vmap(jax.random.split, in_axes=0, out_axes=1)
+        )  # Split all rng keys
+
+    @property
+    def single_action_space(self):
+        """Dynamically adjust action space depending on params"""
+        return gymnax_space_to_gym_space(self._env.action_space(self.env_params))
+
+    @property
+    def single_observation_space(self):
+        """Dynamically adjust state space depending on params"""
+        return gymnax_space_to_gym_space(self._env.observation_space(self.env_params))
+
+    @property
+    def action_space(self):
+        """Dynamically adjust action space depending on params"""
+        return batch_space(self.single_action_space, self.num_envs)
+
+    @property
+    def observation_space(self):
+        """Dynamically adjust state space depending on params"""
+        return batch_space(self.single_observation_space, self.num_envs)
+
+    def _seed(self, seed: Optional[int] = None):
+        """Set RNG seed (or use 0)"""
+        self.rng = jax.random.split(
+            jax.random.PRNGKey(seed or 0), self.num_envs
+        )  # 1 RNG per env
+
+    def reset(
+        self,
+        *,
+        seed: Optional[Union[int, List[int]]] = None,
+        return_info: bool = False,
+        options: Optional[dict] = None,
+    ):
+        """Reset environment, update parameters and seed if provided"""
+        if seed is not None:
+            self._seed(seed)
+        if options is not None:
+            self.env_params = options.get(
+                "env_params", self.env_params
+            )  # Allow changing environment parameters on reset
+        self.rng, reset_key = self._batched_rng_split(self.rng)  # Split all keys
+        o, self.env_state = self._env.reset(reset_key, self.env_params)
+        return o
+
+    def step(
+        self, action: ActType
+    ) -> Union[
+        Tuple[ObsType, float, bool, bool, dict], Tuple[ObsType, float, bool, dict]
+    ]:
+        """Step environment, follow new step API"""
+        self.rng, step_key = self._batched_rng_split(self.rng)
+        o, self.env_state, r, d, info = self._env.step(
+            step_key, self.env_state, action, self.env_params
+        )
+        return o, r, d, d, info
+
+    def render(self, mode="human") -> Optional[Union[RenderFrame, List[RenderFrame]]]:
+        """use underlying environment rendering if it exists (for first environment), otherwise return None"""
+        return getattr(self._env, 'render', lambda x, y: None)(
+            jax.tree_map(lambda x: x[0], self.env_state),
+            self.env_params
+        )

--- a/gymnax/environments/minatar/seaquest.py
+++ b/gymnax/environments/minatar/seaquest.py
@@ -310,7 +310,7 @@ def step_agent(state: EnvState, action: int, env_params: EnvParams) -> EnvState:
     # Update friendly bullets based on f action and shot_timer
     bullet_cond = jnp.logical_and(action == 5, state["shot_timer"] == 0)
     state["shot_timer"] = lax.select(
-        bullet_cond, env_params["shot_cool_down"], state["shot_timer"]
+        bullet_cond, env_params.shot_cool_down, state["shot_timer"]
     )
     bullet_array = jnp.array([state["sub_x"], state["sub_y"], state["sub_or"]])
     # Use counter to keep track of row idx to update!

--- a/gymnax/environments/spaces.py
+++ b/gymnax/environments/spaces.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Sequence, Any
+from typing import Tuple, Sequence, Any, Dict
 from collections import OrderedDict
 import chex
 import jax
@@ -80,11 +80,11 @@ class Box(Space):
 class Dict(Space):
     """Minimal jittable class for dictionary of simpler jittable spaces."""
 
-    def __init__(self, spaces: dict[Any, Space]):
+    def __init__(self, spaces: Dict[Any, Space]):
         self.spaces = spaces
         self.num_spaces = len(spaces)
 
-    def sample(self, rng: chex.PRNGKey) -> dict:
+    def sample(self, rng: chex.PRNGKey) -> Dict:
         """Sample random action from all subspaces."""
         key_split = jax.random.split(rng, self.num_spaces)
         return OrderedDict(
@@ -96,7 +96,7 @@ class Dict(Space):
 
     def contains(self, x: jnp.int_) -> bool:
         """Check whether dimensions of object are within subspace."""
-        # type_cond = isinstance(x, dict)
+        # type_cond = isinstance(x, Dict)
         # num_space_cond = len(x) != len(self.spaces)
         # Check for each space individually
         out_of_space = 0

--- a/gymnax/environments/spaces.py
+++ b/gymnax/environments/spaces.py
@@ -135,8 +135,8 @@ def gymnax_space_to_gym_space(space: Space) -> gspc.Space:
     if isinstance(space, Discrete):
         return gspc.Discrete(space.n)
     elif isinstance(space, Box):
-        low = np.array(space.low) if space.low.size > 1 else float(space.low)
-        high = np.array(space.high) if space.low.size > 1 else float(space.high)
+        low = float(space.low) if (np.isscalar(space.low) or space.low.size == 1) else np.array(space.low)
+        high = float(space.high) if (np.isscalar(space.high) or space.low.size == 1) else np.array(space.high)
         return gspc.Box(low, high, space.shape, space.dtype)
     elif isinstance(space, Dict):
         return gspc.Dict({k: gymnax_space_to_gym_space(v) for k, v in space.spaces})

--- a/gymnax/registration.py
+++ b/gymnax/registration.py
@@ -98,6 +98,7 @@ registered_envs = [
     "Asterix-MinAtar",
     "Breakout-MinAtar",
     "Freeway-MinAtar",
+    "Seaquest-MinAtar",
     "SpaceInvaders-MinAtar",
     "Catch-bsuite",
     "DeepSea-bsuite",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ else:
 git_tar = f"https://github.com/RobertTLange/gymnax/archive/v{verstr}.tar.gz"
 
 requires = ["jax", "jaxlib", "chex", "flax", "pyyaml"]
-test_requires = ["gym>=0.26", "bsuite", "minatar"]
+test_requires = ["gym>=0.26", "bsuite", "minatar", "brax"]
 
 setup(
     name="gymnax",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ else:
 git_tar = f"https://github.com/RobertTLange/gymnax/archive/v{verstr}.tar.gz"
 
 requires = ["jax", "jaxlib", "chex", "flax", "pyyaml"]
-test_requires = ["gym", "bsuite"]
+test_requires = ["gym>=0.26", "bsuite", "minatar"]
 
 setup(
     name="gymnax",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ else:
 git_tar = f"https://github.com/RobertTLange/gymnax/archive/v{verstr}.tar.gz"
 
 requires = ["jax", "jaxlib", "chex", "flax", "pyyaml"]
-test_requires = ["gym>=0.26", "bsuite", "minatar", "brax"]
+test_requires = ["gym>=0.26", "bsuite", "minatar"]
 
 setup(
     name="gymnax",

--- a/tests/classic_control/test_gym_env.py
+++ b/tests/classic_control/test_gym_env.py
@@ -23,7 +23,7 @@ def test_step(gym_env_name):
         for s in range(num_steps):
             action = env_gym.action_space.sample()
             state = np_state_to_jax(env_gym, gym_env_name, get_jax=True)
-            obs_gym, reward_gym, done_gym, _ = env_gym.step(action)
+            obs_gym, reward_gym, done_gym, truncated_gym, _ = env_gym.step(action)
 
             rng, rng_input = jax.random.split(rng)
             obs_jax, state_jax, reward_jax, done_jax, _ = env_jax.step(

--- a/tests/minatar/seaquest_helpers.py
+++ b/tests/minatar/seaquest_helpers.py
@@ -1,5 +1,9 @@
 import numpy as np
 
+shot_cool_down = 5
+diver_move_interval = 5
+enemy_shot_interval = 10
+max_oxygen = 200
 # Update environment according to agent action
 def step_agent_numpy(env, action):
     a = env.env.action_map[action]

--- a/tests/minatar/test_seaquest.py
+++ b/tests/minatar/test_seaquest.py
@@ -45,7 +45,7 @@ def test_sub_steps():
         for s in range(num_steps):
             rng, key_step, key_action = jax.random.split(rng, 3)
             state = np_state_to_jax(env_gym, env_name_jax)
-            action = env_jax.action_space.sample(key_action)
+            action = env_jax.action_space(env_params).sample(key_action)
             action_gym = minatar_action_map(action, env_name_jax)
 
             step_agent_numpy(env_gym, action_gym)

--- a/tests/test_brax.py
+++ b/tests/test_brax.py
@@ -1,13 +1,15 @@
-import brax
 import chex
 import jax
-from brax.envs.wrappers import VmapWrapper, EpisodeWrapper, EvalWrapper
-from gymnax.environments.conversions.brax import GymnaxToBraxWrapper
 import gymnax
 
 
 def test_brax_wrapper():
     """Wrap a Gymnax environment in brax. Use Brax's wrappers to handle vmap and episodes"""
+    try:
+        from brax.envs.wrappers import VmapWrapper, EpisodeWrapper, EvalWrapper
+        from gymnax.environments.conversions.brax import GymnaxToBraxWrapper
+    except ImportError:
+        return
     env, env_params = gymnax.make("CartPole-v1")
     brax_env = GymnaxToBraxWrapper(env)
     wrapped_env = VmapWrapper(EpisodeWrapper(brax_env, 100, 1))

--- a/tests/test_brax.py
+++ b/tests/test_brax.py
@@ -1,0 +1,17 @@
+import brax
+import jax
+from brax.envs.wrappers import VmapWrapper, EpisodeWrapper, EvalWrapper
+from gymnax.environments.conversions.brax import GymnaxToBraxWrapper
+import gymnax
+
+def test_brax_wrapper():
+    env, env_params = gymnax.make('CartPole-v1')
+    brax_env = GymnaxToBraxWrapper(env)
+    wrapped_env = VmapWrapper(EpisodeWrapper(brax_env, 100, 1))
+    B = 16
+    keys = jax.random.split(jax.random.PRNGKey(0), B)
+    reset_fn = jax.jit(wrapped_env.reset)
+    state = reset_fn(keys)
+    step_fn = wrapped_env.step
+    new_state = step_fn(state, jax.numpy.tile(env.action_space(env_params).sample(keys[0]), (B, 1)))
+

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -1,6 +1,5 @@
 import gymnax
 from gymnax.environments.conversions.gym import GymnaxToGymWrapper, GymnaxToVectorGymWrapper
-from gymnax.environments.wrappers.gym import RecordEpisodeStatistics
 import jax
 import jax.numpy as jnp
 import chex

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -1,0 +1,43 @@
+import gymnax
+from gymnax.environments.gym import GymnaxToGymWrapper, GymnaxToVectorGymWrapper
+import jax
+import chex
+import gym
+
+
+def test_gym_wrapper():
+    env, env_params = gymnax.make("FourRooms-misc")
+    e = GymnaxToGymWrapper(env, env_params, 0)
+    a_space, o_space = e.action_space, e.observation_space
+    o = e.reset()
+    next_keys = jax.random.split(jax.random.PRNGKey(0), 2)
+    o_env, env_state = env.reset(next_keys[1], env_params)
+    chex.assert_trees_all_close(o, o_env)
+    chex.assert_trees_all_close(env_state.__dict__, e.env_state.__dict__)
+    chex.assert_trees_all_close(next_keys[0], e.rng)
+    e.reset(seed=5)
+    next_keys = jax.random.split(jax.random.PRNGKey(5), 2)
+    chex.assert_trees_all_close(next_keys[0], e.rng)
+    o, r, d, truncated, info = e.step(a_space.sample())
+    e.render()
+
+
+def test_gym_vector_wrapper():
+    env, env_params = gymnax.make("FourRooms-misc")
+    B = 16  # 16 parallel envs
+    e = GymnaxToVectorGymWrapper(env, B, env_params, 0)
+    a_space, o_space = e.action_space, e.observation_space
+    assert isinstance(a_space, gym.spaces.MultiDiscrete)
+    assert isinstance(o_space, gym.spaces.Box)
+    single_a_space, single_o_space = e.single_action_space, e.single_observation_space
+    assert isinstance(single_a_space, gym.spaces.Discrete)
+    assert isinstance(single_o_space, gym.spaces.Box)
+    keys = jax.random.split(jax.random.PRNGKey(0), B)
+    chex.assert_trees_all_close(e.rng, keys)
+    o = e.reset()
+    env_reset = jax.jit(jax.vmap(env.reset, in_axes=(0, None)))
+    env_step = jax.jit(jax.vmap(env.step, in_axes=(0, 0, 0, None)))
+    o_env, env_state = env_reset(keys, env_params)
+    chex.assert_trees_all_equal_shapes(o_env, o)
+    o, r, d, truncated, info = e.step(e.action_space.sample())
+    e.render()

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -1,6 +1,8 @@
 import gymnax
-from gymnax.environments.gym import GymnaxToGymWrapper, GymnaxToVectorGymWrapper
+from gymnax.environments.conversions.gym import GymnaxToGymWrapper, GymnaxToVectorGymWrapper
+from gymnax.environments.wrappers.gym import RecordEpisodeStatistics
 import jax
+import jax.numpy as jnp
 import chex
 import gym
 
@@ -9,7 +11,7 @@ def test_gym_wrapper():
     env, env_params = gymnax.make("FourRooms-misc")
     e = GymnaxToGymWrapper(env, env_params, 0)
     a_space, o_space = e.action_space, e.observation_space
-    o = e.reset()
+    o, _ = e.reset()
     next_keys = jax.random.split(jax.random.PRNGKey(0), 2)
     o_env, env_state = env.reset(next_keys[1], env_params)
     chex.assert_trees_all_close(o, o_env)
@@ -34,10 +36,12 @@ def test_gym_vector_wrapper():
     assert isinstance(single_o_space, gym.spaces.Box)
     keys = jax.random.split(jax.random.PRNGKey(0), B)
     chex.assert_trees_all_close(e.rng, keys)
-    o = e.reset()
+    o, _ = e.reset()
     env_reset = jax.jit(jax.vmap(env.reset, in_axes=(0, None)))
     env_step = jax.jit(jax.vmap(env.step, in_axes=(0, 0, 0, None)))
     o_env, env_state = env_reset(keys, env_params)
     chex.assert_trees_all_equal_shapes(o_env, o)
     o, r, d, truncated, info = e.step(e.action_space.sample())
     e.render()
+
+


### PR DESCRIPTION
For after #34 

Took a stab at implementing the Brax conversion wrapper and added tests to make sure it's working. A couple notes

1. Uses a "lookalike" Brax state, the only thing that's a bit different is that `state.qp` is no longer a `QP` object, it's whatever the `EnvState` for a particular environment is
2. Uses brax's `state.info` field to maintain and update rng key and env_params so that the `step` and `reset` APIs can match Brax
3. Since action_size and observation_size are properties in Brax, they have to use the default environment parameters
4. Compatible with all Brax wrappers like `VmapWrapper`, `EvalWrapper`, and `EpisodeWrapper`. Obviously not recommended to use `AutoResetWrapper` though.