### PR TITLE
Update the maximum reward a state can have based on optimal_return parameter.

### DIFF
--- a/gymnax/environments/bsuite/discounting_chain.py
+++ b/gymnax/environments/bsuite/discounting_chain.py
@@ -31,9 +31,6 @@ class DiscountingChain(environment.Environment):
         self.n_actions = n_actions
         self.mapping_seed = mapping_seed
 
-        # Setup reward fct fron mapping seed - random sampling outside of env
-        self.reward = jnp.ones(self.n_actions).at[self.mapping_seed].set(1.1)
-
     @property
     def default_params(self) -> EnvParams:
         # Default environment parameters
@@ -69,6 +66,8 @@ class DiscountingChain(environment.Environment):
         self, key: chex.PRNGKey, params: EnvParams
     ) -> Tuple[chex.Array, EnvState]:
         """Reset environment state by sampling initial position."""
+        # Setup reward fct from mapping seed - random sampling outside of env
+        self.reward = jnp.ones(self.n_actions).at[self.mapping_seed].set(params.optimal_return)
         state = EnvState(self.reward, -1, 0)
         return self.get_obs(state, params), state
 
@@ -111,7 +110,7 @@ class DiscountingChain(environment.Environment):
         return spaces.Dict(
             {
                 "rewards": spaces.Box(
-                    1, 1.1, (self.n_actions,), dtype=jnp.float32
+                    1, params.optimal_return, (self.n_actions,), dtype=jnp.float32
                 ),
                 "context": spaces.Box(
                     -1, self.n_actions, (), dtype=jnp.float32


### PR DESCRIPTION
### What?
Changed how `self.reward` is calculated. It is now based on the current value of the `optimal_return` parameter.
## Why?
This is so that if the `optimal_return` is changed, it will change the maximum reward the agent can obtain from a state.
### Extra
Note that this change could potentially make the `reset_env `method slower, as it now calculates the rewards for the states at every reset.

Close #39 