### PR TITLE
Fix reward dtype in FourRooms

### DIFF
--- a/gymnax/environments/misc/rooms.py
+++ b/gymnax/environments/misc/rooms.py
@@ -105,7 +105,7 @@ class FourRooms(environment.Environment):
         new_pos = jax.lax.select(in_map, p, state.pos)
         reward = jnp.logical_and(
             new_pos[0] == state.goal[0], new_pos[1] == state.goal[1]
-        )
+        ) * 1.0
 
         # Update state dict and evaluate termination conditions
         state = EnvState(new_pos, state.goal, state.time + 1)


### PR DESCRIPTION
Based on type annotation and according to tradition, I think this behavior is unexpected.

jnp.logical_and won't convert reward dtype from bool to float. Simply add `*1.0` to convert it.