### PR TITLE
fix bsuite MemoryChain Runtime exception for num_bits > 1

### DIFF
--- a/gymnax/environments/bsuite/memory_chain.py
+++ b/gymnax/environments/bsuite/memory_chain.py
@@ -102,7 +102,9 @@ class MemoryChain(environment.Environment):
         obs = obs.at[1].set(query_val)
         # Show context - only first step.
         context_val = lax.select(
-            state.time == 0, (2 * state.context - 1).squeeze(), 0
+            state.time == 0,
+            (2 * state.context - 1).squeeze(),
+            jnp.zeros(self.num_bits, dtype=jnp.int32).squeeze()
         )
         obs = obs.at[2:].set(context_val)
         return obs


### PR DESCRIPTION
Using `MemoryChain-bsuite` with `num_bits > 1` resulted in 
> TypeError: select cases must have the same shapes

when selecting (masking) the context for current time.

This PR simply fixes this by making sure the negative case array containing only zeros has the same shape as the context.