### PR TITLE
Use `jax.tree.map` because `jax.tree.map` is deprecated

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -435,7 +435,7 @@
     ")\n",
     "\n",
     "# Multiple rollouts for different networks + rng (e.g. for ES)\n",
-    "batch_params = jax.tree_map(  # Stack parameters or use different\n",
+    "batch_params = jax.tree.map(  # Stack parameters or use different\n",
     "    lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params\n",
     ")\n",
     "obs, action, reward, next_obs, done, cum_ret = manager.population_rollout(\n",


### PR DESCRIPTION
`<ipython-input-22-bfd27f6f2527>:8: DeprecationWarning: jax.tree_map is deprecated: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).`