### PR TITLE
Fix num_env_step not working in RolloutWrapper issue

### DIFF
--- a/gymnax/experimental/rollout.py
+++ b/gymnax/experimental/rollout.py
@@ -91,7 +91,7 @@ class RolloutWrapper(object):
                 jnp.array([1.0]),
             ],
             (),
-            self.env_params.max_steps_in_episode,
+            self.num_env_steps,
         )
         # Return the sum of rewards accumulated by agent in episode rollout
         obs, action, reward, next_obs, done = scan_out

--- a/tests/wrappers/test_evaluator.py
+++ b/tests/wrappers/test_evaluator.py
@@ -30,17 +30,17 @@ def test_rollout():
         rng=rng,
     )
     manager = rollout.RolloutWrapper(
-        model.apply, env_name="Pendulum-v1", num_env_steps=200
+        model.apply, env_name="Pendulum-v1", num_env_steps=150
     )
 
     # Test simple single episode rollout
     obs, _, _, _, _, _ = manager.single_rollout(rng, policy_params)
-    assert obs.shape == (200, 3)
+    assert obs.shape == (150, 3)
 
     # Test multiple rollouts for same network (different random numbers)
     rng_batch = jax.random.split(rng, 10)
     obs, _, _, _, _, _ = manager.batch_rollout(rng_batch, policy_params)
-    assert obs.shape == (10, 200, 3)
+    assert obs.shape == (10, 150, 3)
 
     # Test multiple rollouts for different networks
     batch_params = jax.tree_map(
@@ -56,4 +56,4 @@ def test_rollout():
         _,
         _,
     ) = manager.population_rollout(rng_batch, batch_params)
-    assert obs.shape == (5, 10, 200, 3)
+    assert obs.shape == (5, 10, 150, 3)


### PR DESCRIPTION
## Issue #79 
environment made by RolloutWrapper doesn't reflect `num_env_step` variable which we put into `RolloutWrapper`:

## Code for reproduction
```python
from gymnax.experimental import RolloutWrapper
import jax

ENV_NUM = 3
manager = RolloutWrapper(None, env_name='CartPole-v1', num_env_steps=100)

rng, rollout_rng = jax.random.split(jax.random.key(0))
rollout_rng = jax.random.split(rollout_rng, ENV_NUM)
obs, action, reward, next_obs, done, cum_ret = manager.batch_rollout(rollout_rng, None)
print(done.shape) # it should print (3, 100), but the result is (3, 500)
```

## Why this bug happened?
1. `RolloutWrapper.single_rollout()` puts `self.env_params.max_steps_in_episode` in `jax.lax.scan()` instead of `self.num_env_steps` ([gymnax/experimental/rollout.py#L94](https://github.com/RobertTLange/gymnax/blob/main/gymnax/experimental/rollout.py#L94)).
2. Test code  uses `num_env_steps` as sames as enviornment's `max_steps_in_episode` for testing this feature ([gymnax/tests/wrappers/test_evaluator.py](https://github.com/RobertTLange/gymnax/blob/main/tests/wrappers/test_evaluator.py#L33)).

## What is fixed in this PR?
1. Fix `self.env_params.max_steps_in_episode` to `self.num_env_steps` in `RolloutWrapper.single_rollout()` > `jax.lax.scan()`.
2. Fix test code to put different value(200 -> 150) for proper test.