### PR TITLE
Fix the gym visualizer for gymnax.

### DIFF
--- a/gymnax/visualize/visualizer.py
+++ b/gymnax/visualize/visualizer.py
@@ -1,7 +1,6 @@
 """Visualizer for Gymnax environments."""
 
 from typing import Optional
-import gym
 import jax
 import jax.numpy as jnp
 from matplotlib import animation
@@ -68,8 +67,6 @@ class Visualizer(object):
             "MountainCarContinuous-v0",
         ]:
 
-            # Animations have to use older gym version and pyglet!
-            assert gym.__version__ == "0.19.0"
             self.im = vis_gym.init_gym(
                 self.ax, self.env, self.state_seq[0], self.env_params
             )


### PR DESCRIPTION
- gymnax already depends on a newer version of gym, so asserting that gym is 0.19 is completely broken.
- In order to support the newer version of gym, fixed a few small things in the vis_gym.py file:
  - `rgb_array` render method is specified on init now
  - `env.reset()` has to be called before `env.render()`
  - gymnasium envs are wrapped under a few wrapper classes so that overwriting `state` on the outer-most object is not useful at all. Add code to extract the inner most object and set the `state` vector there.

[Tested on MountainCar](https://github.com/user-attachments/assets/f04c5605-c3c6-4d5b-a441-a2a568ed2e17)
