### PR TITLE
Remove calls to deprecated `tree_map`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ In order to use JAX on your accelerators, you can find more details in the [JAX 
   )
 
   # Multiple rollouts for different networks + rng (e.g. for ES)
-  batch_params = jax.tree_map(  # Stack parameters or use different
+  batch_params = jax.tree.map(  # Stack parameters or use different
       lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params
   )
   obs, action, reward, next_obs, done, cum_ret = manager.population_rollout(

--- a/examples/01_anakin.ipynb
+++ b/examples/01_anakin.ipynb
@@ -212,8 +212,8 @@
     "    learn = jax.pmap(learn, axis_name='i')  # replicate over multiple cores.\n",
     "\n",
     "    broadcast = lambda x: jnp.broadcast_to(x, (cores_count, batch_size) + x.shape)\n",
-    "    params = jax.tree_map(broadcast, params)  # broadcast to cores and batch.\n",
-    "    opt_state = jax.tree_map(broadcast, opt_state)  # broadcast to cores and batch\n",
+    "    params = jax.tree.map(broadcast, params)  # broadcast to cores and batch.\n",
+    "    opt_state = jax.tree.map(broadcast, opt_state)  # broadcast to cores and batch\n",
     "\n",
     "    rng, *env_rngs = jax.random.split(rng, cores_count * batch_size + 1)\n",
     "    env_obs, env_states = jax.vmap(env.reset)(jnp.stack(env_rngs))  # init envs.\n",
@@ -251,8 +251,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/tree_util.py:188: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
-      "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
+      "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/tree_util.py:188: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree.map() instead as a drop-in replacement.\n",
+      "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree.map() '\n"
      ]
     },
     {
@@ -285,7 +285,7 @@
     "# Get model ready for evaluation - squeeze broadcasted params\n",
     "model = get_network_fn(env.num_actions)\n",
     "squeeze = lambda x: x[0][0]\n",
-    "params = jax.tree_map(squeeze, batch_params)\n",
+    "params = jax.tree.map(squeeze, batch_params)\n",
     "\n",
     "# Simple single episode rollout for policy\n",
     "rng = jax.random.PRNGKey(0)"

--- a/examples/03_meta_a2c.ipynb
+++ b/examples/03_meta_a2c.ipynb
@@ -71,7 +71,7 @@
       },
       "outputs": [],
       "source": [
-        "from typing import NamedTuple, Tuple, Optional\n",
+        "from typing import TYPE_CHECKING, NamedTuple, Tuple, Optional\n",
         "\n",
         "import chex\n",
         "import distrax\n",

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -435,7 +435,7 @@
     ")\n",
     "\n",
     "# Multiple rollouts for different networks + rng (e.g. for ES)\n",
-    "batch_params = jax.tree_map(  # Stack parameters or use different\n",
+    "batch_params = jax.tree.map(  # Stack parameters or use different\n",
     "    lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params\n",
     ")\n",
     "obs, action, reward, next_obs, done, cum_ret = manager.population_rollout(\n",

--- a/gymnax/__init__.py
+++ b/gymnax/__init__.py
@@ -1,7 +1,6 @@
 """Gymnax: A library for creating and registering Gym environments."""
 
-from gymnax import environments
-from gymnax import registration
+from gymnax import environments, registration
 
 EnvParams = environments.EnvParams
 EnvState = environments.EnvState

--- a/gymnax/environments/__init__.py
+++ b/gymnax/environments/__init__.py
@@ -1,11 +1,6 @@
 """Gymnax environments."""
 
-from gymnax.environments import bsuite
-from gymnax.environments import classic_control
-from gymnax.environments import environment
-from gymnax.environments import minatar
-from gymnax.environments import misc
-
+from gymnax.environments import bsuite, classic_control, environment, minatar, misc
 
 Catch = bsuite.Catch
 DeepSea = bsuite.DeepSea

--- a/gymnax/environments/bsuite/__init__.py
+++ b/gymnax/environments/bsuite/__init__.py
@@ -1,13 +1,14 @@
 """Bsuite environments."""
 
-from gymnax.environments.bsuite import bandit
-from gymnax.environments.bsuite import catch
-from gymnax.environments.bsuite import deep_sea
-from gymnax.environments.bsuite import discounting_chain
-from gymnax.environments.bsuite import memory_chain
-from gymnax.environments.bsuite import mnist
-from gymnax.environments.bsuite import umbrella_chain
-
+from gymnax.environments.bsuite import (
+    bandit,
+    catch,
+    deep_sea,
+    discounting_chain,
+    memory_chain,
+    mnist,
+    umbrella_chain,
+)
 
 SimpleBandit = bandit.SimpleBandit
 Catch = catch.Catch

--- a/gymnax/environments/bsuite/bandit.py
+++ b/gymnax/environments/bsuite/bandit.py
@@ -1,25 +1,28 @@
 """JAX compatible version of the bandit environment from bsuite."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     rewards: Union[chex.Array, float]
     total_regret: float
     time: Union[float, chex.Array]
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     optimal_return: float = 1.0
     max_steps_in_episode: int = 100

--- a/gymnax/environments/bsuite/catch.py
+++ b/gymnax/environments/bsuite/catch.py
@@ -4,20 +4,23 @@
 Source: github.com/deepmind/bsuite/blob/master/bsuite/environments/catch.py.
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     ball_x: chex.Array
     ball_y: chex.Array
@@ -27,7 +30,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     max_steps_in_episode: int = 1000
 

--- a/gymnax/environments/bsuite/deep_sea.py
+++ b/gymnax/environments/bsuite/deep_sea.py
@@ -1,18 +1,21 @@
 """DeepSea bsuite environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     row: int
     column: int
@@ -24,7 +27,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     deterministic: bool = True
     sample_action_map: bool = False

--- a/gymnax/environments/bsuite/discounting_chain.py
+++ b/gymnax/environments/bsuite/discounting_chain.py
@@ -6,23 +6,28 @@ github.com/deepmind/bsuite/blob/master/bsuite/environments/discounting_chain.py.
 """
 
 import dataclasses
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+
 import chex
-from flax import struct
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     rewards: chex.Array
     context: jnp.ndarray
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     reward_timestep: chex.Array = dataclasses.field(
         default_factory=lambda: jnp.array([1, 3, 10, 30, 100])

--- a/gymnax/environments/bsuite/memory_chain.py
+++ b/gymnax/environments/bsuite/memory_chain.py
@@ -5,19 +5,22 @@ Source:
 github.com/deepmind/bsuite/blob/master/bsuite/environments/memory_chain.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     context: jnp.int32
     query: jnp.int32
@@ -26,7 +29,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     memory_length: int = 5
     max_steps_in_episode: int = 1000

--- a/gymnax/environments/bsuite/mnist.py
+++ b/gymnax/environments/bsuite/mnist.py
@@ -1,26 +1,29 @@
 """MNIST bandit environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
 from gymnax.utils import load_mnist
 
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
-@struct.dataclass
+
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     correct_label: chex.Array
     regret: chex.Array
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     optimal_return: int = 1
     max_steps_in_episode: int = 1

--- a/gymnax/environments/bsuite/umbrella_chain.py
+++ b/gymnax/environments/bsuite/umbrella_chain.py
@@ -5,19 +5,22 @@ Source:
 github.com/deepmind/bsuite/blob/master/bsuite/environments/umbrella_chain.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     need_umbrella: jnp.int32
     has_umbrella: jnp.int32
@@ -25,7 +28,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     chain_length: int = 10
     max_steps_in_episode: int = 100

--- a/gymnax/environments/classic_control/__init__.py
+++ b/gymnax/environments/classic_control/__init__.py
@@ -1,11 +1,12 @@
 """Classic control environments."""
 
-from gymnax.environments.classic_control import acrobot
-from gymnax.environments.classic_control import cartpole
-from gymnax.environments.classic_control import continuous_mountain_car
-from gymnax.environments.classic_control import mountain_car
-from gymnax.environments.classic_control import pendulum
-
+from gymnax.environments.classic_control import (
+    acrobot,
+    cartpole,
+    continuous_mountain_car,
+    mountain_car,
+    pendulum,
+)
 
 Acrobot = acrobot.Acrobot
 CartPole = cartpole.CartPole

--- a/gymnax/environments/classic_control/acrobot.py
+++ b/gymnax/environments/classic_control/acrobot.py
@@ -6,17 +6,22 @@ Note that we only implement the default 'book' version.
 """
 
 import dataclasses
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     joint_angle1: jnp.ndarray
     joint_angle2: jnp.ndarray
@@ -25,7 +30,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     """Environment parameters for Acrobot."""
 

--- a/gymnax/environments/classic_control/cartpole.py
+++ b/gymnax/environments/classic_control/cartpole.py
@@ -1,18 +1,21 @@
 """JAX compatible version of CartPole-v1 OpenAI gym environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     x: jnp.ndarray
     x_dot: jnp.ndarray
@@ -21,7 +24,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     gravity: float = 9.8
     masscart: float = 1.0

--- a/gymnax/environments/classic_control/continuous_mountain_car.py
+++ b/gymnax/environments/classic_control/continuous_mountain_car.py
@@ -5,26 +5,29 @@ Source:
 github.com/openai/gym/blob/master/gym/envs/classic_control/continuous_mountain_car.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     position: jnp.ndarray
     velocity: jnp.ndarray
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     min_action: float = -1.0
     max_action: float = 1.0

--- a/gymnax/environments/classic_control/mountain_car.py
+++ b/gymnax/environments/classic_control/mountain_car.py
@@ -5,26 +5,29 @@ Source:
 github.com/openai/gym/blob/master/gym/envs/classic_control/mountain_car.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     position: jnp.ndarray
     velocity: jnp.ndarray
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     min_position: float = -1.2
     max_position: float = 0.6

--- a/gymnax/environments/classic_control/pendulum.py
+++ b/gymnax/environments/classic_control/pendulum.py
@@ -4,19 +4,22 @@
 Source: github.com/openai/gym/blob/master/gym/envs/classic_control/pendulum.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     theta: jnp.ndarray
     theta_dot: jnp.ndarray
@@ -24,7 +27,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     max_speed: float = 8.0
     max_torque: float = 2.0

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -1,23 +1,37 @@
 """Abstract base class for all gymnax Environments."""
 
 import functools
-from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
+
 import chex
-from flax import struct
 import jax
 import jax.numpy as jnp
 
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 TEnvState = TypeVar("TEnvState", bound="EnvState")
 TEnvParams = TypeVar("TEnvParams", bound="EnvParams")
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     max_steps_in_episode: int = 1
 

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -59,7 +59,7 @@ class Environment(Generic[TEnvState, TEnvParams]):  # object):
         obs_st, state_st, reward, done, info = self.step_env(key, state, action, params)
         obs_re, state_re = self.reset_env(key_reset, params)
         # Auto-reset environment based on termination
-        state = jax.tree_map(
+        state = jax.tree.map(
             lambda x, y: jax.lax.select(done, x, y), state_re, state_st
         )
         obs = jax.lax.select(done, obs_re, obs_st)

--- a/gymnax/environments/minatar/__init__.py
+++ b/gymnax/environments/minatar/__init__.py
@@ -1,9 +1,6 @@
 """Minatar environments."""
 
-from gymnax.environments.minatar import asterix
-from gymnax.environments.minatar import breakout
-from gymnax.environments.minatar import freeway
-from gymnax.environments.minatar import space_invaders
+from gymnax.environments.minatar import asterix, breakout, freeway, space_invaders
 
 # from gymnax.environments.minatar import seaquest
 

--- a/gymnax/environments/minatar/asterix.py
+++ b/gymnax/environments/minatar/asterix.py
@@ -17,19 +17,22 @@ ENVIRONMENT DESCRIPTION - 'Asterix-MinAtar'
 - Actions are encoded as: ['n', 'l', 'u', 'r', 'd']
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     """State of the environment."""
 
@@ -47,7 +50,7 @@ class EnvState(environment.EnvState):
     terminal: bool
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     ramping: bool = True
     ramp_interval: int = 100

--- a/gymnax/environments/minatar/breakout.py
+++ b/gymnax/environments/minatar/breakout.py
@@ -1,18 +1,21 @@
 """JAX compatible version of Breakout MinAtar environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     ball_y: jnp.ndarray
     ball_x: jnp.ndarray
@@ -26,7 +29,7 @@ class EnvState(environment.EnvState):
     terminal: bool
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     max_steps_in_episode: int = 1000
 

--- a/gymnax/environments/minatar/freeway.py
+++ b/gymnax/environments/minatar/freeway.py
@@ -20,19 +20,22 @@ ENVIRONMENT DESCRIPTION - 'Freeway-MinAtar'
 - Actions are encoded as follows: ['n', 'u', 'd']
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     pos: int
     cars: chex.Array
@@ -41,7 +44,7 @@ class EnvState(environment.EnvState):
     terminal: bool
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     player_speed: int = 3
     max_steps_in_episode: int = 2500

--- a/gymnax/environments/minatar/seaquest.py
+++ b/gymnax/environments/minatar/seaquest.py
@@ -1,11 +1,14 @@
 # """JAX compatible version of Seaquest MinAtar environment."""
 
 
-# from typing import Any, Dict, Optional, Tuple, Union
+# from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 
 # import chex
-# from flax import struct
+# if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+#     from dataclasses import dataclass
+# else:
+#     from chex import dataclass
 # from gymnax.environments import environment
 # from gymnax.environments import spaces
 # import jax
@@ -13,7 +16,7 @@
 # import jax.numpy as jnp
 
 
-# @struct.dataclass
+# @dataclass(frozen=True)
 # class EnvState(environment.EnvState):
 #   """State of the environment."""
 
@@ -43,7 +46,7 @@
 #   terminal: bool
 
 
-# @struct.dataclass
+# @dataclass(frozen=True)
 # class EnvParams(environment.EnvParams):
 #   ramping: bool = True
 #   ramp_interval: int = 100

--- a/gymnax/environments/minatar/space_invaders.py
+++ b/gymnax/environments/minatar/space_invaders.py
@@ -22,19 +22,22 @@ ENVIRONMENT DESCRIPTION - 'SpaceInvaders-MinAtar'
 - Actions are encoded as follows: ['n','l','r','f']
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     """State of the environment."""
 
@@ -53,7 +56,7 @@ class EnvState(environment.EnvState):
     terminal: bool
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     shot_cool_down: int = 5
     enemy_move_interval: int = 12

--- a/gymnax/environments/misc/__init__.py
+++ b/gymnax/environments/misc/__init__.py
@@ -1,14 +1,15 @@
 """Miscellaneous environments."""
 
-from gymnax.environments.misc import bernoulli_bandit
-from gymnax.environments.misc import gaussian_bandit
-from gymnax.environments.misc import meta_maze
-from gymnax.environments.misc import point_robot
-from gymnax.environments.misc import pong
-from gymnax.environments.misc import reacher
-from gymnax.environments.misc import rooms
-from gymnax.environments.misc import swimmer
-
+from gymnax.environments.misc import (
+    bernoulli_bandit,
+    gaussian_bandit,
+    meta_maze,
+    point_robot,
+    pong,
+    reacher,
+    rooms,
+    swimmer,
+)
 
 BernoulliBandit = bernoulli_bandit.BernoulliBandit
 GaussianBandit = gaussian_bandit.GaussianBandit

--- a/gymnax/environments/misc/bernoulli_bandit.py
+++ b/gymnax/environments/misc/bernoulli_bandit.py
@@ -1,18 +1,21 @@
 """JAX version of a Bernoulli bandit environment as in Wang et al. 2017."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     last_action: jnp.ndarray
     last_reward: jnp.ndarray
@@ -21,7 +24,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     reward_prob: float = 0.1
     normalize_time: bool = True

--- a/gymnax/environments/misc/gaussian_bandit.py
+++ b/gymnax/environments/misc/gaussian_bandit.py
@@ -1,18 +1,21 @@
 """Gaussian bandit environment as in Lange & Sprekeler (2022)."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     last_action: int
     last_reward: jnp.ndarray
@@ -20,7 +23,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     mean_mu: float = -1.0  # Mean of stochastic arm
     sigma_p: float = 1.0  # Standard deviation between 'episode'

--- a/gymnax/environments/misc/meta_maze.py
+++ b/gymnax/environments/misc/meta_maze.py
@@ -5,20 +5,23 @@ Source: Comparable to
 github.com/uber-research/backpropamine/blob/master/simplemaze/maze.py
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     last_action: int
     last_reward: jnp.ndarray
@@ -27,7 +30,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     # github.com/uber-research/backpropamine/blob/180c9101fa5be5a2da205da3399a92773d395091/simplemaze/maze.py#L414-L431
     reward: float = 10.0

--- a/gymnax/environments/misc/point_robot.py
+++ b/gymnax/environments/misc/point_robot.py
@@ -1,19 +1,22 @@
 """Point Robot environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     last_action: chex.Array
     last_reward: jnp.ndarray
@@ -23,7 +26,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     max_force: float = 0.1  # Max action (+/-)
     circle_radius: float = 1.0  # Radius of semi-circle

--- a/gymnax/environments/misc/pong.py
+++ b/gymnax/environments/misc/pong.py
@@ -6,22 +6,25 @@ https://github.com/BlackHC/batch_pong_poc/blob/master/src/vanilla_pong.py -
 Actions are encoded as: ['n', 'u', 'd']
 """
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from matplotlib import colors
 import matplotlib.pyplot as plt
 import seaborn as sns
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+from matplotlib import colors
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     paddle_centers: chex.Array
     ball_position: chex.Array
@@ -31,7 +34,7 @@ class EnvState(environment.EnvState):
     terminal: bool
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     ball_max_y_speed: int = 3
     paddle_y_speed: int = 1

--- a/gymnax/environments/misc/reacher.py
+++ b/gymnax/environments/misc/reacher.py
@@ -1,18 +1,21 @@
 """Reacher environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     angles: chex.Array
     angle_vels: chex.Array
@@ -20,7 +23,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     torque_scale: float = 1.0
     dt: float = 0.05

--- a/gymnax/environments/misc/rooms.py
+++ b/gymnax/environments/misc/rooms.py
@@ -5,27 +5,30 @@ Source: Comparable to https://github.com/howardh/gym-fourrooms Since gymnax
 automatically resets env at done, we abstract different resets
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     pos: chex.Array
     goal: chex.Array
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     fail_prob: float = 1.0 / 3
     resample_init_pos: bool = False

--- a/gymnax/environments/misc/swimmer.py
+++ b/gymnax/environments/misc/swimmer.py
@@ -1,18 +1,21 @@
 """Swimmer environment."""
 
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
-from jax import lax
 import jax.numpy as jnp
-from gymnax.environments import environment
-from gymnax.environments import spaces
+from jax import lax
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState(environment.EnvState):
     urchin_xys: chex.Array
     xy: chex.Array
@@ -21,7 +24,7 @@ class EnvState(environment.EnvState):
     time: float
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     dt: float = 0.05
     max_steps_in_episode: int = 500  # Steps in an episode (constant goal)

--- a/gymnax/environments/spaces.py
+++ b/gymnax/environments/spaces.py
@@ -2,12 +2,12 @@
 
 import collections
 from typing import Any, Sequence, Union
+
 import chex
-# from gym import spaces as gspc
-from gymnasium import spaces as gspc
 import jax
 import jax.numpy as jnp
 import numpy as np
+from gymnasium import spaces as gspc
 
 
 class Space:

--- a/gymnax/experimental/__init__.py
+++ b/gymnax/experimental/__init__.py
@@ -2,7 +2,6 @@
 
 from gymnax.experimental import rollout
 
-
 RolloutWrapper = rollout.RolloutWrapper
 
 

--- a/gymnax/experimental/rollout.py
+++ b/gymnax/experimental/rollout.py
@@ -1,9 +1,11 @@
 """Rollout wrapper for gymnax environments."""
 
 import functools
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
 import jax
 import jax.numpy as jnp
+
 import gymnax
 
 

--- a/gymnax/experimental/rollout.py
+++ b/gymnax/experimental/rollout.py
@@ -93,7 +93,7 @@ class RolloutWrapper(object):
                 jnp.array([1.0]),
             ],
             (),
-            self.env_params.max_steps_in_episode,
+            self.num_env_steps,
         )
         # Return the sum of rewards accumulated by agent in episode rollout
         obs, action, reward, next_obs, done = scan_out

--- a/gymnax/registration.py
+++ b/gymnax/registration.py
@@ -1,30 +1,32 @@
 """A JAX-version of OpenAI's infamous env.make(env_name)."""
 
-from gymnax.environments.bsuite import bandit
-from gymnax.environments.bsuite import catch
-from gymnax.environments.bsuite import deep_sea
-from gymnax.environments.bsuite import discounting_chain
-from gymnax.environments.bsuite import memory_chain
-from gymnax.environments.bsuite import mnist
-from gymnax.environments.bsuite import umbrella_chain
-from gymnax.environments.classic_control import acrobot
-from gymnax.environments.classic_control import cartpole
-from gymnax.environments.classic_control import continuous_mountain_car
-from gymnax.environments.classic_control import mountain_car
-from gymnax.environments.classic_control import pendulum
-from gymnax.environments.minatar import asterix
-from gymnax.environments.minatar import breakout
-from gymnax.environments.minatar import freeway
-from gymnax.environments.minatar import space_invaders
-from gymnax.environments.misc import bernoulli_bandit
-from gymnax.environments.misc import gaussian_bandit
-from gymnax.environments.misc import meta_maze
-from gymnax.environments.misc import point_robot
-from gymnax.environments.misc import pong
-from gymnax.environments.misc import reacher
-from gymnax.environments.misc import rooms
-from gymnax.environments.misc import swimmer
-
+from gymnax.environments.bsuite import (
+    bandit,
+    catch,
+    deep_sea,
+    discounting_chain,
+    memory_chain,
+    mnist,
+    umbrella_chain,
+)
+from gymnax.environments.classic_control import (
+    acrobot,
+    cartpole,
+    continuous_mountain_car,
+    mountain_car,
+    pendulum,
+)
+from gymnax.environments.minatar import asterix, breakout, freeway, space_invaders
+from gymnax.environments.misc import (
+    bernoulli_bandit,
+    gaussian_bandit,
+    meta_maze,
+    point_robot,
+    pong,
+    reacher,
+    rooms,
+    swimmer,
+)
 
 # =============================================================================
 

--- a/gymnax/utils/__init__.py
+++ b/gymnax/utils/__init__.py
@@ -1,8 +1,6 @@
 """Utility functions for Gymnax."""
 
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
-
+from gymnax.utils import state_translate, test_helpers
 
 np_state_to_jax = state_translate.np_state_to_jax
 assert_correct_state = test_helpers.assert_correct_state

--- a/gymnax/utils/load_mnist.py
+++ b/gymnax/utils/load_mnist.py
@@ -25,12 +25,11 @@ and https://github.com/deepmind/bsuite/blob/master/bsuite/utils/datasets.py
 import array
 import gzip
 import os
-from os import path
 import struct
+from os import path
 
-
-from absl import logging
 import numpy as np
+from absl import logging
 from six.moves.urllib.request import urlretrieve
 
 

--- a/gymnax/utils/state_translate.py
+++ b/gymnax/utils/state_translate.py
@@ -1,22 +1,24 @@
 """Helper functions to translate gym state to JAX state."""
 
 import jax.numpy as jnp
-from gymnax.environments.bsuite import bandit
-from gymnax.environments.bsuite import catch
-from gymnax.environments.bsuite import deep_sea
-from gymnax.environments.bsuite import discounting_chain
-from gymnax.environments.bsuite import memory_chain
-from gymnax.environments.bsuite import mnist
-from gymnax.environments.bsuite import umbrella_chain
-from gymnax.environments.classic_control import acrobot
-from gymnax.environments.classic_control import cartpole
-from gymnax.environments.classic_control import continuous_mountain_car
-from gymnax.environments.classic_control import mountain_car
-from gymnax.environments.classic_control import pendulum
-from gymnax.environments.minatar import asterix
-from gymnax.environments.minatar import breakout
-from gymnax.environments.minatar import freeway
-from gymnax.environments.minatar import space_invaders
+
+from gymnax.environments.bsuite import (
+    bandit,
+    catch,
+    deep_sea,
+    discounting_chain,
+    memory_chain,
+    mnist,
+    umbrella_chain,
+)
+from gymnax.environments.classic_control import (
+    acrobot,
+    cartpole,
+    continuous_mountain_car,
+    mountain_car,
+    pendulum,
+)
+from gymnax.environments.minatar import asterix, breakout, freeway, space_invaders
 
 # from gymnax.environments.minatar import seaquest
 

--- a/gymnax/utils/test_helpers.py
+++ b/gymnax/utils/test_helpers.py
@@ -1,9 +1,11 @@
 """Helper functions for testing."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
 import jax
 import jaxlib
 import numpy as np
+
 from gymnax.utils import state_translate
 
 

--- a/gymnax/visualize/__init__.py
+++ b/gymnax/visualize/__init__.py
@@ -2,7 +2,6 @@
 
 from gymnax.visualize import visualizer
 
-
 Visualizer = visualizer.Visualizer
 
 

--- a/gymnax/visualize/vis_minatar.py
+++ b/gymnax/visualize/vis_minatar.py
@@ -1,8 +1,8 @@
 """Visualize Minatar environments."""
 
-from matplotlib import colors
 import numpy as np
 import seaborn as sns
+from matplotlib import colors
 
 
 def init_minatar(ax, env, state):

--- a/gymnax/visualize/visualizer.py
+++ b/gymnax/visualize/visualizer.py
@@ -1,17 +1,15 @@
 """Visualizer for Gymnax environments."""
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
 import gym
 import jax
 import jax.numpy as jnp
-from matplotlib import animation
 import matplotlib.pyplot as plt
+from matplotlib import animation
+
 import gymnax
-from gymnax.visualize import vis_catch
-from gymnax.visualize import vis_circle
-from gymnax.visualize import vis_gym
-from gymnax.visualize import vis_maze
-from gymnax.visualize import vis_minatar
+from gymnax.visualize import vis_catch, vis_circle, vis_gym, vis_maze, vis_minatar
 
 
 class Visualizer(object):

--- a/gymnax/wrappers/__init__.py
+++ b/gymnax/wrappers/__init__.py
@@ -1,9 +1,6 @@
 """Wrappers for Gymnax environments."""
 
-from gymnax.wrappers import dm_env
-from gymnax.wrappers import gym
-from gymnax.wrappers import purerl
-
+from gymnax.wrappers import dm_env, gym, purerl
 
 GymnaxToDmEnvWrapper = dm_env.GymnaxToDmEnvWrapper
 GymnaxToGymWrapper = gym.GymnaxToGymWrapper

--- a/gymnax/wrappers/brax.py
+++ b/gymnax/wrappers/brax.py
@@ -1,13 +1,16 @@
 """Wrappers for Gymnax environments to be compatible with Brax."""
 
-from typing import Any, Dict, Optional, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import chex
-from flax import struct
 import jax
+
 from gymnax.environments import environment
 
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 try:
     from brax import envs
 except ImportError as exc:
@@ -16,7 +19,7 @@ except ImportError as exc:
     ) from exc
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class State:  # Lookalike for brax.envs.env.State.
     qp: environment.EnvState  # Brax QP is roughly equivalent to our EnvState
     obs: Any  # depends on environment

--- a/gymnax/wrappers/dm_env.py
+++ b/gymnax/wrappers/dm_env.py
@@ -1,16 +1,22 @@
 """DM env API wrapper for gymnax environment."""
 
 import functools
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
+
 import chex
-from flax import struct
 import jax
 import jax.numpy as jnp
+
 from gymnax.environments import environment
 from gymnax.wrappers import purerl
 
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
-@struct.dataclass
+
+@dataclass(frozen=True)
 class TimeStep:
     state: environment.EnvState
     reward: chex.Array

--- a/gymnax/wrappers/evojax.py
+++ b/gymnax/wrappers/evojax.py
@@ -1,20 +1,24 @@
 """Utility wrapper to port gymnax env to evoJAX tasks."""
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
+
 import chex
-from flax import struct
-import gymnax
-from gymnax.environments import environment
 import jax
 
+import gymnax
+from gymnax.environments import environment
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 try:
-    from evojax.task.base import VectorizedTask
-    from evojax.task.base import TaskState
+    from evojax.task.base import TaskState, VectorizedTask
 except Exception as exc:
     raise ImportError("You need to additionally install EvoJAX.") from exc
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class GymState(TaskState):
     state: environment.EnvState
     obs: chex.Array

--- a/gymnax/wrappers/gym.py
+++ b/gymnax/wrappers/gym.py
@@ -1,16 +1,15 @@
 """Wrappers for Gymnax environments to be used in Gym."""
 
 import copy
-from typing import Any, Dict, List, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import chex
 import gymnasium as gym
+import jax.random
 from gymnasium import core
 from gymnasium.vector import utils
-import jax.random
-from gymnax.environments import environment
-from gymnax.environments import spaces
+
+from gymnax.environments import environment, spaces
 
 
 class GymnaxToGymWrapper(gym.Env[core.ObsType, core.ActType]):

--- a/gymnax/wrappers/gym.py
+++ b/gymnax/wrappers/gym.py
@@ -197,5 +197,5 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
     ) -> Optional[Union[core.RenderFrame, List[core.RenderFrame]]]:
         """use underlying environment rendering if it exists (for first environment), otherwise return None."""
         return getattr(self._env, "render", lambda x, y: None)(
-            jax.tree_map(lambda x: x[0], self.env_state), self.env_params
+            jax.tree.map(lambda x: x[0], self.env_state), self.env_params
         )

--- a/gymnax/wrappers/purerl.py
+++ b/gymnax/wrappers/purerl.py
@@ -85,7 +85,7 @@ class LogWrapper(GymnaxWrapper):
         self, key: chex.PRNGKey, params: Optional[environment.EnvParams] = None
     ) -> Tuple[chex.Array, LogEnvState]:
         obs, env_state = self._env.reset(key, params)
-        state = LogEnvState(env_state, 0, 0, 0, 0)
+        state = LogEnvState(env_state, 0.0, 0, 0.0, 0)
         return obs, state
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/gymnax/wrappers/purerl.py
+++ b/gymnax/wrappers/purerl.py
@@ -1,16 +1,19 @@
 """Wrappers for pure RL."""
 
 import functools
-from typing import Any, Dict, Optional, Tuple, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
 import jax
 import jax.numpy as jnp
 import numpy as np
-from gymnax.environments import environment
-from gymnax.environments import spaces
+
+from gymnax.environments import environment, spaces
+
+if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
+    from dataclasses import dataclass
+else:
+    from chex import dataclass
 
 
 class GymnaxWrapper(object):
@@ -62,7 +65,7 @@ class FlattenObservationWrapper(GymnaxWrapper):
         return obs, state, reward, done, info
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class LogEnvState:
     env_state: environment.EnvState
     episode_returns: float

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
     from distutils.core import setup, find_packages
 
-
-import re
 import os
-from typing import List
+import re
+from typing import TYPE_CHECKING, List
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -35,7 +34,6 @@ requires = [
     "jax",
     "jaxlib",
     "chex",
-    "flax",
     "pyyaml",
     "gym>=0.26",
     "gymnasium",

--- a/tests/classic_control/test_gym_env.py
+++ b/tests/classic_control/test_gym_env.py
@@ -2,10 +2,9 @@
 
 import gym
 import jax
-import gymnax
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
 
+import gymnax
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 10, 150, 1e-04
 

--- a/tests/control_bsuite/test_bsuite_env.py
+++ b/tests/control_bsuite/test_bsuite_env.py
@@ -1,17 +1,18 @@
 """Tests for bsuite environments."""
 
 import jax
-import gymnax
-from bsuite.environments import bandit
-from bsuite.environments import catch
-from bsuite.environments import deep_sea
-from bsuite.environments import discounting_chain
-from bsuite.environments import memory_chain
-from bsuite.environments import mnist
-from bsuite.environments import umbrella_chain
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
+from bsuite.environments import (
+    bandit,
+    catch,
+    deep_sea,
+    discounting_chain,
+    memory_chain,
+    mnist,
+    umbrella_chain,
+)
 
+import gymnax
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 10, 150, 1e-04
 

--- a/tests/minatar/test_asterix.py
+++ b/tests/minatar/test_asterix.py
@@ -1,13 +1,12 @@
 """Tests for the Asterix environment."""
 
+import asterix_helpers
 import jax
 from minatar import environment
-import asterix_helpers
+
 import gymnax
 from gymnax.environments.minatar import asterix
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
-
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 5, 10, 1e-04
 env_name_gym, env_name_jax = "asterix", "Asterix-MinAtar"

--- a/tests/minatar/test_breakout.py
+++ b/tests/minatar/test_breakout.py
@@ -1,14 +1,12 @@
 """Tests for the breakout environment."""
 
+import breakout_helpers
 import jax
 from minatar import environment
 
-import breakout_helpers
 import gymnax
 from gymnax.environments.minatar import breakout
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
-
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 5, 10, 1e-04
 env_name_gym, env_name_jax = "breakout", "Breakout-MinAtar"

--- a/tests/minatar/test_freeway.py
+++ b/tests/minatar/test_freeway.py
@@ -3,14 +3,12 @@
 import freeway_helpers
 import jax
 import jax.numpy as jnp
-from minatar import environment
 import numpy as np
+from minatar import environment
 
 import gymnax
 from gymnax.environments.minatar import freeway
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
-
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 5, 10, 1e-04
 env_name_gym, env_name_jax = "freeway", "Freeway-MinAtar"

--- a/tests/minatar/test_space_invaders.py
+++ b/tests/minatar/test_space_invaders.py
@@ -1,14 +1,12 @@
 """Tests for the Space Invaders environment."""
 
-import space_invaders_helpers
 import jax
+import space_invaders_helpers
 from minatar import environment
 
 import gymnax
 from gymnax.environments.minatar import space_invaders
-from gymnax.utils import state_translate
-from gymnax.utils import test_helpers
-
+from gymnax.utils import state_translate, test_helpers
 
 num_episodes, num_steps, tolerance = 5, 10, 1e-04
 env_name_gym, env_name_jax = "space_invaders", "SpaceInvaders-MinAtar"

--- a/tests/misc/test_misc_env.py
+++ b/tests/misc/test_misc_env.py
@@ -1,8 +1,8 @@
 """Tests for misc environments."""
 
 import jax
-import gymnax
 
+import gymnax
 
 num_episodes, num_steps, tolerance = 10, 100, 1e-04
 

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,11 +1,12 @@
 """Tests for the visualizer."""
 
 import os
+
 import jax
 import jax.numpy as jnp
+
 import gymnax
 from gymnax.visualize import visualizer
-
 
 
 def test_visualizer(viz_env_name: str):

--- a/tests/wrappers/test_brax.py
+++ b/tests/wrappers/test_brax.py
@@ -1,10 +1,11 @@
 """Tests for brax wrapper."""
 
-from brax import envs
 import chex
+import jax
+from brax import envs
+
 import gymnax
 from gymnax.wrappers import brax
-import jax
 
 
 def test_brax_wrapper():

--- a/tests/wrappers/test_dm_env.py
+++ b/tests/wrappers/test_dm_env.py
@@ -2,6 +2,7 @@
 
 import chex
 import jax
+
 import gymnax
 from gymnax.wrappers import dm_env
 

--- a/tests/wrappers/test_evaluator.py
+++ b/tests/wrappers/test_evaluator.py
@@ -44,11 +44,11 @@ def test_rollout():
     assert obs.shape == (10, 150, 3)
 
     # Test multiple rollouts for different networks
-    batch_params = jax.tree_map(
+    batch_params = jax.tree.map(
         lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params
     )
-    # print(jax.tree_map(lambda x: x.shape, policy_params))
-    # print(jax.tree_map(lambda x: x.shape, batch_params))
+    # print(jax.tree.map(lambda x: x.shape, policy_params))
+    # print(jax.tree.map(lambda x: x.shape, batch_params))
     (
         obs,
         _,

--- a/tests/wrappers/test_evaluator.py
+++ b/tests/wrappers/test_evaluator.py
@@ -3,6 +3,7 @@
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+
 from gymnax.experimental import rollout
 
 

--- a/tests/wrappers/test_evaluator.py
+++ b/tests/wrappers/test_evaluator.py
@@ -31,17 +31,17 @@ def test_rollout():
         rng=rng,
     )
     manager = rollout.RolloutWrapper(
-        model.apply, env_name="Pendulum-v1", num_env_steps=200
+        model.apply, env_name="Pendulum-v1", num_env_steps=150
     )
 
     # Test simple single episode rollout
     obs, _, _, _, _, _ = manager.single_rollout(rng, policy_params)
-    assert obs.shape == (200, 3)
+    assert obs.shape == (150, 3)
 
     # Test multiple rollouts for same network (different random numbers)
     rng_batch = jax.random.split(rng, 10)
     obs, _, _, _, _, _ = manager.batch_rollout(rng_batch, policy_params)
-    assert obs.shape == (10, 200, 3)
+    assert obs.shape == (10, 150, 3)
 
     # Test multiple rollouts for different networks
     batch_params = jax.tree_map(
@@ -57,4 +57,4 @@ def test_rollout():
         _,
         _,
     ) = manager.population_rollout(rng_batch, batch_params)
-    assert obs.shape == (5, 10, 200, 3)
+    assert obs.shape == (5, 10, 150, 3)

--- a/tests/wrappers/test_gym.py
+++ b/tests/wrappers/test_gym.py
@@ -3,6 +3,7 @@
 import chex
 import gymnasium as gym
 import jax
+
 import gymnax
 from gymnax.wrappers import gym as wrappers
 


### PR DESCRIPTION
This replaces calls to deprecated `jax.tree_map` with `jax.tree.map`, so that this works with newer versions of `jax`.