### PR TITLE
Deepsea equivalence

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/bsuite/bsuite"]
+	path = tests/bsuite/bsuite
+	url = https://github.com/knyazer/bsuite

--- a/gymnax/environments/bsuite/deep_sea.py
+++ b/gymnax/environments/bsuite/deep_sea.py
@@ -3,7 +3,6 @@
 from typing import Any, Dict, Optional, Tuple, Union
 
 
-import chex
 from flax import struct
 import jax
 from jax import lax
@@ -20,7 +19,7 @@ class EnvState(environment.EnvState):
     total_bad_episodes: int
     denoised_return: int
     optimal_return: float
-    action_mapping: chex.Array
+    action_mapping: Any  # float array
     time: int
 
 
@@ -45,7 +44,7 @@ class DeepSea(environment.Environment[EnvState, EnvParams]):
         self,
         size: int = 8,
         randomize_actions=True,
-        action_mapping_rng_key: chex.PRNGKey = jax.random.PRNGKey(42),
+        action_mapping_rng_key=jax.random.key(42),
         **kws,
     ):
         super().__init__()
@@ -64,8 +63,8 @@ class DeepSea(environment.Environment[EnvState, EnvParams]):
         return self._params
 
     def step_env(
-        self, key: chex.PRNGKey, state: EnvState, action: int, params: EnvParams
-    ) -> Tuple[chex.Array, EnvState, float, bool, dict]:
+        self, key: Any, state: EnvState, action: int, params: EnvParams
+    ) -> Tuple[Any, EnvState, float, bool, dict]:
         """Perform single timestep state transition."""
         # Pull out randomness for easier testing
         rng_reward, rng_trans = jax.random.split(key)
@@ -106,9 +105,7 @@ class DeepSea(environment.Environment[EnvState, EnvParams]):
             info,
         )
 
-    def reset_env(
-        self, key: chex.PRNGKey, params: EnvParams
-    ) -> Tuple[chex.Array, EnvState]:
+    def reset_env(self, key: Any, params: EnvParams) -> Tuple[Any, EnvState]:
         """Reset environment state by sampling initial position."""
         optimal_no_cost = (1 - params.deterministic) * (1 - 1 / self.size) ** (
             self.size - 1
@@ -136,7 +133,7 @@ class DeepSea(environment.Environment[EnvState, EnvParams]):
 
         return self.get_obs(state), state
 
-    def get_obs(self, state: EnvState, params=None, key=None) -> chex.Array:
+    def get_obs(self, state: EnvState, params=None, key=None) -> Any:
         """Return observation from raw state trafo."""
         obs_end = jnp.zeros(shape=(self.size, self.size), dtype=jnp.float32)
         end_cond = state.row >= self.size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dev = [
     "mypy",
 ]
 test = [
-    "chex",
     "flax",
     "brax",
     "minatar",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "mypy",
 ]
 test = [
+    "chex",
     "flax",
     "brax",
     "minatar",

--- a/tests/bsuite/test.py
+++ b/tests/bsuite/test.py
@@ -1,0 +1,124 @@
+import gymnax
+import jax
+import jax.numpy as jnp
+from itertools import product
+from bsuite.environments.deep_sea import DeepSea
+import numpy as np
+import jax.random as jr
+
+
+def generate_all_action_sequences(size):
+    """Generate all possible action sequences for DeepSea environment.
+
+    Each episode lasts exactly `size` steps, with binary actions (0 or 1).
+    Returns all 2^size possible sequences.
+    """
+    return list(product([0, 1], repeat=size))
+
+
+def run_episode_original(env, action_sequence):
+    """Run a complete episode on the original bsuite environment."""
+    total_reward = 0.0
+    timestep = env.reset()
+
+    for action in action_sequence:
+        timestep = env.step(action)
+        total_reward += timestep.reward
+    assert timestep.last()
+
+    return total_reward
+
+
+def run_episode_gymnax(env, env_params, action_sequence, key):
+    """Run a complete episode on the gymnax environment."""
+    obs, state = env.reset(key, env_params)
+    total_reward = 0.0
+
+    for action in action_sequence:
+        key, subkey = jax.random.split(key)
+        obs, state, reward, done, info = env.step(subkey, state, action, env_params)
+        total_reward += reward
+
+    assert done
+    return float(total_reward)
+
+
+def deepsea_equivalence(env_config):
+    """Test that both DeepSea implementations produce identical rewards for all action sequences."""
+
+    # Initialize both environments with same seeds
+    original_env = DeepSea(
+        **env_config,
+        seed=0,
+        mapping_seed=0,
+    )
+
+    our_env, env_params = gymnax.make(
+        "DeepSea-bsuite", **env_config, action_mapping_rng_key=jr.key(0)
+    )
+    # TODO: generalize this by making a monkey-patched generators for jax/numpy/random etc
+    if ("randomize_actions" not in env_config) or env_config["randomize_actions"]:
+        our_env.fixed_action_mapping = jnp.asarray(original_env._action_mapping).astype(
+            jnp.bool_
+        )
+    key = jr.key(0)
+
+    # Generate all possible action sequences for the environment size
+    all_sequences = generate_all_action_sequences(env_config["size"])
+
+    mismatches = []
+
+    for i, action_sequence in enumerate(all_sequences):
+        # Run episode on original environment
+        original_reward = run_episode_original(original_env, action_sequence)
+        assert (our_env.fixed_action_mapping == original_env._action_mapping).all()
+
+        # Run episode on gymnax environment
+        key, subkey = jax.random.split(key)
+        gymnax_reward = run_episode_gymnax(our_env, env_params, action_sequence, subkey)
+
+        # Compare rewards with small tolerance for floating point differences
+        if not np.isclose(original_reward, gymnax_reward, rtol=1e-6, atol=1e-6):
+            mismatches.append(
+                {
+                    "sequence": action_sequence,
+                    "original_reward": original_reward,
+                    "gymnax_reward": gymnax_reward,
+                    "difference": abs(original_reward - gymnax_reward),
+                }
+            )
+
+    # Report results
+    if mismatches:
+        print(f"\nFound {len(mismatches)} mismatches!")
+        for mismatch in mismatches[:10]:  # Show first 10 mismatches
+            print(f"Sequence: {mismatch['sequence']}")
+            print(f"  Original: {mismatch['original_reward']}")
+            print(f"  Gymnax:   {mismatch['gymnax_reward']}")
+            print(f"  Diff:     {mismatch['difference']}")
+
+        if len(mismatches) > 10:
+            print(f"... and {len(mismatches) - 10} more mismatches")
+
+        assert False, f"Reward mismatches found in {len(mismatches)} sequences"
+
+
+def test_deepsea_equivalence():
+    for size in [4, 8]:
+        for deterministic in [True]:
+            for unscaled_move_cost in [0, 0.01]:
+                for randomize_actions in [True, False]:
+                    env_config = {
+                        "size": size,
+                        "deterministic": deterministic,
+                        "unscaled_move_cost": unscaled_move_cost,
+                        "randomize_actions": randomize_actions,
+                    }
+                    deepsea_equivalence(env_config)
+    # test the default parameters
+    env_config = {"size": 12}
+    deepsea_equivalence(env_config)
+
+
+if __name__ == "__main__":
+    test_deepsea_equivalence()


### PR DESCRIPTION
Heya, Rob,

First, **This PR includes a breaking change, do not merge it**!

So I've spent this week largely trying to force jaxtyping upon the codebase (in jaxtyping branch of my repo), and fixing the typing errors that were present. However, this PR is not about it.

It is about the fact that the environment you are calling DeepSea-bsuite, does not actually correspond to DeepSea-bsuite. This was already mentioned in #77 , and largely fixed by it. Like, the default parameters are a bit wrong (the randomize_actions should be True, not False), and the randomization logic overall was wrong. I fixed it, and also wrote a very extensive test for the fix.

There is a bunch of stuff left over from the fix - feel free to merge this, but it will take a bit more time for me to prepare it for the actual production, since I need to like cleanup the code a bit, update Actions and the usage tutorial to include ```git submodule``` stuff, etc

But before doing all of that I wanted you to take a look and tell me: maybe it was intentional? I mean, I don't think so, but just in case, WDYT?

Besides this, this also kinda relates to #88 , since it is pretty hard to address EnvState for a particular Env directly: I'm just allowing to modify the default parameters for this particular instance of the environment by passing more kwargs. If you are happy with something like this, I will incorporate it into all other environments.