### PR TITLE
Fix(visualizer): Update rendering for compatibility with Gymnasium v1.0.0+

### DIFF
--- a/gymnax/visualize/vis_gym.py
+++ b/gymnax/visualize/vis_gym.py
@@ -65,6 +65,7 @@ def update_gym(im, env, state):
         gym_env = gym.make("Pendulum-v0", render_mode="rgb_array")
     else:
         gym_env = gym.make(env.name, render_mode="rgb_array")
+    gym_env.reset()
     gym_state = get_gym_state(state, env.name)
     if env.name == "Pendulum-v1":
         gym_env.env.last_u = gym_state[-1]

--- a/gymnax/visualize/vis_gym.py
+++ b/gymnax/visualize/vis_gym.py
@@ -43,16 +43,16 @@ def get_gym_state(state, env_name):
 def init_gym(ax, env, state, params):
     """Initialize gym environment."""
     if env.name == "Pendulum-v1":
-        gym_env = gym.make("Pendulum-v0")
+        gym_env = gym.make("Pendulum-v0", render_mode="rgb_array")
     else:
-        gym_env = gym.make(env.name)
+        gym_env = gym.make(env.name, render_mode="rgb_array")
     gym_env.reset()
     set_gym_params(gym_env, env.name, params)
     gym_state = get_gym_state(state, env.name)
     if env.name == "Pendulum-v1":
         gym_env.env.last_u = gym_state[-1]
     gym_env.env.state = gym_state
-    rgb_array = gym_env.render(mode="rgb_array")
+    rgb_array = gym_env.render()
     ax.set_xticks([])
     ax.set_yticks([])
     gym_env.close()
@@ -62,14 +62,14 @@ def init_gym(ax, env, state, params):
 def update_gym(im, env, state):
     """Update gym environment."""
     if env.name == "Pendulum-v1":
-        gym_env = gym.make("Pendulum-v0")
+        gym_env = gym.make("Pendulum-v0", render_mode="rgb_array")
     else:
-        gym_env = gym.make(env.name)
+        gym_env = gym.make(env.name, render_mode="rgb_array")
     gym_state = get_gym_state(state, env.name)
     if env.name == "Pendulum-v1":
         gym_env.env.last_u = gym_state[-1]
     gym_env.env.state = gym_state
-    rgb_array = gym_env.render(mode="rgb_array")
+    rgb_array = gym_env.render()
     im.set_data(rgb_array)
     gym_env.close()
     return im


### PR DESCRIPTION
# Gymnax Visualizer Update: Modern Gymnasium API Compatibility

## Summary
This pull request updates the `gymnax.visualize.vis_gym` module to restore compatibility with the modern rendering API used in gymnasium versions 1.0.0 and newer. The current implementation fails when used with recent versions of gymnasium, raising `TypeError` and `ResetNeeded` errors.

## The Problem
With the release of gymnasium v0.26.0 and its stabilization in v1.0.0+, the API for rendering environments has changed significantly. This has introduced two breaking issues for the gymnax visualizer:

### 1. TypeError: Unexpected 'mode' Argument
```python
TypeError: Wrapper.render() got an unexpected keyword argument 'mode'
```
The `render_mode` is no longer passed as an argument to the `.render()` method. Instead, it must be specified upon environment creation via `gym.make(env_name, render_mode="rgb_array")`.

### 2. ResetNeeded Error
```python
ResetNeeded: Cannot call env.render() before calling env.reset()
```
gymnasium now strictly enforces that `env.reset()` must be called on an environment instance before any calls to `env.render()`. The `update_gym` function in the visualizer creates a new environment for each animation frame but fails to reset it, triggering this error.

These issues effectively prevent the use of `gymnax.visualize` in any project using up-to-date dependencies.

## The Solution
This PR makes the following minimal changes to `gymnax/visualize/vis_gym.py` to align with the modern gymnasium API:

### 1. Modernized gym.make() Calls
In both `init_gym` and `update_gym`, the environment creation call has been changed to:
```python
gym.make(env.name, render_mode="rgb_array")
```

### 2. Updated .render() Calls
All calls to `gym_env.render(mode="rgb_array")` have been simplified to:
```python
gym_env.render()
```
as the render mode is now handled at initialization.

### 3. Added env.reset() in update_gym
A `gym_env.reset()` line has been added immediately after `gym.make()` inside the `update_gym` function. This satisfies the render order enforcement and resolves the `ResetNeeded` error.

These changes restore the visualizer's functionality while respecting the new API standards of its core dependency.

## How to Test
This fix can be verified by:

1. Ensuring gymnasium>=1.0.0 is installed:
   ```bash
   pip install "gymnasium>=1.2.0"
   ```

2. Running a script that uses `gymnax.visualize.Visualizer` to animate an episode (e.g., for "CartPole-v1")

3. Confirming that the animation is generated and saved without errors 