### PR TITLE
Add terminal states informations

### DIFF
--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -9,6 +9,7 @@ from typing import (
 )
 
 import jax
+import jax.numpy as jnp
 from flax import struct
 
 TEnvState = TypeVar("TEnvState", bound="EnvState")
@@ -56,6 +57,12 @@ class Environment(Generic[TEnvState, TEnvParams]):
             lambda x, y: jax.lax.select(done, x, y), state_re, state_st
         )
         obs = jax.lax.select(done, obs_re, obs_st)
+
+        # Keep track of obs_st on terminal states
+        info["obs_st"] = obs_st
+        info["state_st"] = state_st
+        info["truncated"] = state_st.time >= params.max_steps_in_episode
+        info["terminated"] = jnp.logical_and(done,jnp.logical_not(info["truncated"]))
 
         return obs, state, reward, done, info
 

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -60,7 +60,6 @@ class Environment(Generic[TEnvState, TEnvParams]):
 
         # Keep track of obs_st on terminal states
         info["obs_st"] = obs_st
-        info["state_st"] = state_st
         info["truncated"] = state_st.time >= params.max_steps_in_episode
         info["terminated"] = jnp.logical_and(done,jnp.logical_not(info["truncated"]))
 

--- a/tests/test_terminal_states.py
+++ b/tests/test_terminal_states.py
@@ -1,0 +1,48 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import gymnax
+
+
+@pytest.mark.parametrize(
+    "env_id",
+    [
+        "CartPole-v1",  # Allows early termination
+        "Pendulum-v1",  # No early termination
+    ],
+)
+def test_truncation(env_id):
+    env, env_params = gymnax.make(env_id)
+    key = jax.random.PRNGKey(42)
+
+    _, state = env.reset(key)
+    action = env.action_space(env_params).sample(key)
+
+    def step_fn(state, _):
+        next_obs, next_state, _, done, info = env.step(key, state, action, env_params)
+        return next_state, (next_obs, done, info)
+
+    _, (observations, dones, infos) = jax.lax.scan(
+        f=step_fn, init=state, xs=None, length=env_params.max_steps_in_episode + 1
+    )
+
+    # Should have at least finished once due to truncation
+    assert sum(dones) >= 1
+    for i, (obs, done, info) in enumerate(zip(observations, dones, infos)):
+        if state.time == env_params.max_steps_in_episode - 1:
+            if i + 1 <= len(observations):
+                # Should have truncated
+                assert infos[i + 1]["truncated"]
+                assert not infos[i + 1]["terminated"]
+                assert dones[i + 1]
+                # Last obs from finished episode should be different from \\
+                # first obs of new episode
+                assert not jnp.array_equal(infos[i + 1]["obs_st"], obs)
+        else:
+            if done:
+                assert info["terminated"]
+                assert not info["truncated"]
+                # Last obs from finished episode should be different from \\
+                # first obs of new episode
+                assert not jnp.array_equal(infos[i + 1]["obs_st"], obs)

--- a/tests/test_terminal_states.py
+++ b/tests/test_terminal_states.py
@@ -5,6 +5,17 @@ import pytest
 import gymnax
 
 
+def split_env_state(state):
+    # stack into list of trees (length = number of timesteps)
+    return [jax.tree.map(lambda x: x[i], state) for i in range(len(state.time))]
+
+
+def split_state_dict(state: dict):
+    keys = state.keys()
+    arrays = state.values()
+    return [{k: v for k, v in zip(keys, values)} for values in zip(*arrays)]
+
+
 @pytest.mark.parametrize(
     "env_id",
     [
@@ -21,28 +32,37 @@ def test_truncation(env_id):
 
     def step_fn(state, _):
         next_obs, next_state, _, done, info = env.step(key, state, action, env_params)
-        return next_state, (next_obs, done, info)
+        return next_state, (next_obs, next_state, done, info)
 
-    _, (observations, dones, infos) = jax.lax.scan(
+    _, (observations, states, dones, infos) = jax.lax.scan(
         f=step_fn, init=state, xs=None, length=env_params.max_steps_in_episode + 1
     )
 
     # Should have at least finished once due to truncation
     assert sum(dones) >= 1
-    for i, (obs, done, info) in enumerate(zip(observations, dones, infos)):
-        if state.time == env_params.max_steps_in_episode - 1:
-            if i + 1 <= len(observations):
-                # Should have truncated
-                assert infos[i + 1]["truncated"]
-                assert not infos[i + 1]["terminated"]
-                assert dones[i + 1]
-                # Last obs from finished episode should be different from \\
-                # first obs of new episode
-                assert not jnp.array_equal(infos[i + 1]["obs_st"], obs)
+    infos = split_state_dict(infos)
+    states = split_env_state(states)
+    for i, (obs, state, done, info) in enumerate(
+        zip(observations, states, dones, infos)
+    ):
+        if i == 0:
+            # Need to observe the step before, not possible at i=0.
+            continue
+        if states[i - 1].time == env_params.max_steps_in_episode - 1:
+            # Should have truncated
+            assert info["truncated"]
+            assert not info["terminated"]
+            assert done
+            # Last obs from finished episode should be different from \\
+            # first obs of new episode
+            assert not jnp.array_equal(info["obs_st"], obs)
+        elif done:
+            assert info["terminated"]
+            assert not info["truncated"]
+            # Last obs from finished episode should be different from \\
+            # first obs of new episode
+            assert not jnp.array_equal(info["obs_st"], obs)
         else:
-            if done:
-                assert info["terminated"]
-                assert not info["truncated"]
-                # Last obs from finished episode should be different from \\
-                # first obs of new episode
-                assert not jnp.array_equal(infos[i + 1]["obs_st"], obs)
+            assert not info["truncated"]
+            assert not info["terminated"]
+            assert jnp.array_equal(info["obs_st"], obs)


### PR DESCRIPTION
Hello,

By default, the environment only returns a single done flag at terminal states. As explained [here](https://farama.org/Gymnasium-Terminated-Truncated-Step-API), it is important to distinguish between termination and truncation.

Switching the API to return terminated and truncated directly would be a breaking change. While I support this in the future (e.g., 1.0.0), I propose in the meantime adding these flags to the info dict. This lightweight change requires no modifications to Gymnax and would already be useful by default.

Another key issue for truncation handling is the terminal observation. For value function learning, termination implies the last state’s value is always 0, while truncation does not. However, because Gymnax auto-resets environments, the returned observation at termination is from the next episode, not the last state. This prevents correct value estimation and may cause implementations to mistakenly bootstrap from the new episode’s first state instead of the final state of the previous one.
To fix this, I propose exposing the would-be next observation in the info dict. This preserves auto-reset while enabling correct handling of truncation.

All changes are non-breaking; I’ve added tests and linted.