### PR TITLE
fix: expose LogWrapper return validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### [Unreleased]
 
 - Added a concise Gymnax 1.0 migration summary to the README.
+- Added a persistent `LogWrapper` validity signal that distinguishes reset
+  placeholders from completed-episode returns and lengths.
 
 ### [v1.0.0] - 16/08/2026
 

--- a/gymnax/wrappers/purerl.py
+++ b/gymnax/wrappers/purerl.py
@@ -147,10 +147,16 @@ class LogEnvState:
     episode_lengths: jax.Array
     returned_episode_returns: jax.Array
     returned_episode_lengths: jax.Array
+    returned_episode_valid: jax.Array
 
 
 class LogWrapper(GymnaxWrapper):
-    """Log the episode returns and lengths."""
+    """Log episode returns and lengths.
+
+    ``returned_episode`` marks a transition that completed an episode, while
+    ``returned_episode_valid`` remains true after the first completed episode.
+    Until then, the returned episode counters contain reset placeholders.
+    """
 
     #   def __init__(self, env: environment.Environment):
     #     super().__init__(env)
@@ -166,6 +172,7 @@ class LogWrapper(GymnaxWrapper):
             jnp.array(0, dtype=jnp.int32),
             jnp.array(0, dtype=jnp.float32),
             jnp.array(0, dtype=jnp.int32),
+            jnp.array(False, dtype=jnp.bool_),
         )
         return obs, state
 
@@ -204,8 +211,10 @@ class LogWrapper(GymnaxWrapper):
             + new_episode_return * done,
             returned_episode_lengths=state.returned_episode_lengths * (1 - done)
             + new_episode_length * done,
+            returned_episode_valid=jnp.logical_or(state.returned_episode_valid, done),
         )
         info["returned_episode_returns"] = state.returned_episode_returns
         info["returned_episode_lengths"] = state.returned_episode_lengths
         info["returned_episode"] = done
+        info["returned_episode_valid"] = state.returned_episode_valid
         return obs, state, reward, terminated, truncated, info

--- a/tests/wrappers/test_purerl.py
+++ b/tests/wrappers/test_purerl.py
@@ -32,6 +32,60 @@ def test_log_wrapper_reset_and_step_share_jit_state_dtypes():
         assert next_state.returned_episode_returns.dtype == jnp.float32
         assert next_state.episode_lengths.dtype == jnp.int32
         assert next_state.returned_episode_lengths.dtype == jnp.int32
+        assert next_state.returned_episode_valid.dtype == jnp.bool_
+
+
+def test_log_wrapper_marks_zero_return_valid_after_first_completed_episode():
+    env, _ = gymnax.make("Catch-bsuite")
+    params = env.default_params.replace(max_steps_in_episode=2)
+    wrapper = LogWrapper(env)
+    reset_key, first_key, terminal_key, next_episode_key = jax.random.split(
+        jax.random.key(1), 4
+    )
+    _, state = wrapper.reset(reset_key, params)
+
+    assert not state.returned_episode_valid
+
+    _, state, _, _, _, info = wrapper.step(first_key, state, jnp.int32(1), params)
+
+    assert not info["returned_episode"]
+    assert not info["returned_episode_valid"]
+
+    _, state, _, _, truncated, info = wrapper.step(
+        terminal_key, state, jnp.int32(1), params
+    )
+
+    assert truncated
+    assert info["returned_episode"]
+    assert info["returned_episode_valid"]
+    assert info["returned_episode_returns"] == 0.0
+    assert info["returned_episode_lengths"] == 2
+
+    _, state, _, _, _, info = wrapper.step(
+        next_episode_key, state, jnp.int32(1), params
+    )
+
+    assert not info["returned_episode"]
+    assert info["returned_episode_valid"]
+    assert state.returned_episode_valid
+    assert state.returned_episode_returns == 0.0
+    assert state.returned_episode_lengths == 2
+
+
+def test_log_wrapper_batches_return_validity_with_vmap():
+    env, _ = gymnax.make("Catch-bsuite")
+    params = env.default_params.replace(max_steps_in_episode=1)
+    wrapper = LogWrapper(env)
+    reset_keys = jax.random.split(jax.random.key(2), 3)
+    step_keys = jax.random.split(jax.random.key(3), 3)
+    _, states = jax.vmap(wrapper.reset, in_axes=(0, None))(reset_keys, params)
+
+    _, states, _, _, _, info = jax.vmap(wrapper.step, in_axes=(0, 0, 0, None))(
+        step_keys, states, jnp.ones(3, dtype=jnp.int32), params
+    )
+
+    assert jnp.array_equal(states.returned_episode_valid, jnp.ones(3, dtype=bool))
+    assert jnp.array_equal(info["returned_episode_valid"], jnp.ones(3, dtype=bool))
 
 
 def test_sticky_action_wrapper_defaults_to_passthrough_and_records_action():


### PR DESCRIPTION
## What changed

- add persistent `returned_episode_valid` to `LogEnvState`
- expose the same boolean in step `info`
- preserve `returned_episode` as the current-step completion pulse
- cover reset, zero-return completion, persistence, JIT dtype stability, and vmap batching

## Why

`returned_episode_returns == 0` and `returned_episode_lengths == 0` are valid episode statistics, so the reset placeholders were ambiguous until the first episode completed. A persistent boolean resolves that ambiguity without changing numeric counter dtypes or using JAX-unsafe `None` values.

## Verification

- `uv run python -m pytest -q tests/wrappers/test_purerl.py` — 15 passed
- `JAX_ENABLE_X64=1 uv run python -m pytest -q tests/wrappers/test_purerl.py -k log_wrapper` — 3 passed
- `uv run python -m pytest -q --all` — 172 passed, 3 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build`

Closes #62
