### PR TITLE
feat: add opt-in differentiable transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added a concise Gymnax 1.0 migration summary to the README.
 - Added a persistent `LogWrapper` validity signal that distinguishes reset
   placeholders from completed-episode returns and lengths.
+- Added opt-in differentiable observations and states for the five built-in
+  continuous-action environments while preserving stop-gradient defaults.
 
 ### [v1.0.0] - 16/08/2026
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,43 @@ bootstrap_mask = 1.0 - info["terminated"].astype(jnp.float32)
 `spaces.Discrete(n, dtype=...)` uses `int32` actions by default. `int64` is
 available only when JAX x64 mode is enabled; other dtypes are unsupported.
 
+## Differentiable transitions
+
+Built-in environments detach transition observations and states by default.
+Continuous-control applications can opt into JAX gradients without changing
+the original environment:
+
+```python
+env, env_params = gymnax.make("Pendulum-v1")
+differentiable_env = env.with_transition_gradients()
+obs, state = differentiable_env.reset(key_reset, env_params)
+
+def next_angular_velocity(action):
+    return differentiable_env.step(key_step, state, action, env_params)[1].theta_dot
+
+action = jnp.array([0.5])
+transition_gradient = jax.grad(next_angular_velocity)(action)
+```
+
+`with_transition_gradients()` returns a configured copy, leaving `env`
+unchanged. It is supported by `Pendulum-v1`, `MountainCarContinuous-v0`,
+`PointRobot-misc`, `Reacher-misc`, and `Swimmer-misc`. Configure the environment
+before applying wrappers. Discrete-action environments such as `CartPole-v1`
+reject this opt-in because action derivatives are not part of their contract.
+
+These are local, pathwise derivatives of the JAX program for a fixed random
+key. Clipping boundaries, comparisons, terminal decisions, and discrete events
+are not smooth; PointRobot's goal-triggered respawn is also discontinuous.
+Differentiate floating-point state leaves rather than the complete state PyTree,
+which includes integer bookkeeping such as `time`.
+
+Automatic reset behavior is unchanged. On a terminal or truncated step, the
+returned observation and state belong to the reset episode and therefore do not
+carry the completed transition's action gradient. The gradient remains available
+through `info["final_observation"]`; use `step_env` when the raw, non-autoreset
+next state is required. Reward gradients are unaffected by the opt-in and remain
+available wherever the reward implementation is differentiable.
+
 ## Implemented Accelerated Environments 🏎️
 
 

--- a/docs/api_rfc.md
+++ b/docs/api_rfc.md
@@ -123,14 +123,41 @@ are not required hooks for new environments.
    six-value API, and the opt-in five-value compatibility adapter.
 3. Released: 1.0.0 migration notes and wrapper contract coverage.
 
-Open issues #109, #38, #103, #107, #88, #59, #32, and #26 remain the public
+Issues #109, #38, #103, #107, #88, #59, #32, and #26 served as the public
 discussion and implementation trackers. Pull request #108 was useful reference
-material for the completed 0.x change, but does not itself resolve the 1.0 API
+material for the completed 0.x change, but did not itself resolve the 1.0 API
 migration.
 
 ## Deferred decisions
 
-This RFC intentionally does not consolidate constructor arguments into
-`EnvParams`, expose terminal states, or define environment reward derivatives.
-Those remain separate proposals after the terminal and observation contracts are
-stable.
+The 1.0 RFC intentionally did not consolidate constructor arguments into
+`EnvParams`, expose terminal states, or define transition derivatives. Those
+questions were evaluated separately after the terminal and observation contracts
+stabilized.
+
+## Post-1.0 differentiable transition contract
+
+Built-in environments retain their stop-gradient behavior by default. The five
+continuous-action environments (`Pendulum-v1`, `MountainCarContinuous-v0`,
+`PointRobot-misc`, `Reacher-misc`, and `Swimmer-misc`) declare support for
+`env.with_transition_gradients()`. This method returns a new configured
+environment; the original instance remains unchanged, and the new identity keeps
+JIT caching explicit.
+
+Configured environments preserve JAX gradients through transition observations
+and floating-point state leaves. They do not return derivative values directly;
+callers use `jax.grad`, `jax.jacrev`, or related transformations. Reward gradients
+are unchanged by this mode. Unsupported environments reject the opt-in rather
+than implying differentiability for discrete actions or event-driven dynamics.
+
+The contract is pathwise and local to the executed JAX program with a fixed
+random key. It does not promise smooth derivatives through clipping boundaries,
+comparisons, discrete events, termination decisions, or PointRobot's conditional
+respawn. Integer state leaves such as `time` are bookkeeping, not differentiation
+targets.
+
+Automatic reset retains the 1.0 semantics. After termination or truncation, the
+publicly returned observation and state come from reset and have no action
+gradient from the completed transition. `info["final_observation"]` preserves the
+transition-observation gradient, while `step_env` exposes the raw next state
+without autoreset.

--- a/gymnax/environments/classic_control/continuous_mountain_car.py
+++ b/gymnax/environments/classic_control/continuous_mountain_car.py
@@ -38,6 +38,8 @@ class EnvParams(environment.EnvParams):
 class ContinuousMountainCar(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible  version of MountainCarContinuous-v0 OpenAI gym environment."""
 
+    supports_transition_gradients = True
+
     @property
     def default_params(self) -> EnvParams:
         # Default environment parameters
@@ -74,9 +76,12 @@ class ContinuousMountainCar(environment.Environment[EnvState, EnvParams]):
             time=state.time + 1,
         )
         done = self.is_terminal(state, params)
+        observation, state = self._apply_transition_gradient_policy(
+            self.get_obs(state), state
+        )
         return (
-            jax.lax.stop_gradient(self.get_obs(state)),
-            jax.lax.stop_gradient(state),
+            observation,
+            state,
             reward,
             done,
             {"discount": self.discount(state, params)},

--- a/gymnax/environments/classic_control/continuous_mountain_car.py
+++ b/gymnax/environments/classic_control/continuous_mountain_car.py
@@ -38,7 +38,7 @@ class EnvParams(environment.EnvParams):
 class ContinuousMountainCar(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible  version of MountainCarContinuous-v0 OpenAI gym environment."""
 
-    supports_transition_gradients = True
+    _supports_transition_gradients = True
 
     @property
     def default_params(self) -> EnvParams:

--- a/gymnax/environments/classic_control/pendulum.py
+++ b/gymnax/environments/classic_control/pendulum.py
@@ -35,7 +35,7 @@ class EnvParams(environment.EnvParams):
 class Pendulum(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible version of Pendulum-v0 OpenAI gym environment."""
 
-    supports_transition_gradients = True
+    _supports_transition_gradients = True
 
     def __init__(self):
         super().__init__()

--- a/gymnax/environments/classic_control/pendulum.py
+++ b/gymnax/environments/classic_control/pendulum.py
@@ -35,6 +35,8 @@ class EnvParams(environment.EnvParams):
 class Pendulum(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible version of Pendulum-v0 OpenAI gym environment."""
 
+    supports_transition_gradients = True
+
     def __init__(self):
         super().__init__()
         self.obs_shape = (3,)
@@ -79,9 +81,12 @@ class Pendulum(environment.Environment[EnvState, EnvParams]):
             time=state.time + 1,
         )
         done = self.is_terminal(state, params)
+        observation, state = self._apply_transition_gradient_policy(
+            self.get_obs(state), state
+        )
         return (
-            jax.lax.stop_gradient(self.get_obs(state)),
-            jax.lax.stop_gradient(state),
+            observation,
+            state,
             reward,
             done,
             {"discount": self.discount(state, params)},

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -26,8 +26,13 @@ class EnvParams:
 class Environment(Generic[TEnvState, TEnvParams]):
     """Abstract base class for environments."""
 
-    supports_transition_gradients = False
+    _supports_transition_gradients = False
     _transition_gradients_enabled = False
+
+    @property
+    def supports_transition_gradients(self) -> bool:
+        """Whether this environment implements differentiable transitions."""
+        return self._supports_transition_gradients
 
     @property
     def transition_gradients_enabled(self) -> bool:

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -1,5 +1,6 @@
 """Abstract base class for all gymnax Environments."""
 
+import copy
 from functools import partial
 from typing import Any, Generic, TypeVar
 
@@ -9,6 +10,7 @@ from flax import struct
 
 TEnvState = TypeVar("TEnvState", bound="EnvState")
 TEnvParams = TypeVar("TEnvParams", bound="EnvParams")
+TEnvironment = TypeVar("TEnvironment", bound="Environment")
 
 
 @struct.dataclass
@@ -23,6 +25,31 @@ class EnvParams:
 
 class Environment(Generic[TEnvState, TEnvParams]):
     """Abstract base class for environments."""
+
+    supports_transition_gradients = False
+    _transition_gradients_enabled = False
+
+    @property
+    def transition_gradients_enabled(self) -> bool:
+        """Whether transition observations and states preserve gradients."""
+        return self._transition_gradients_enabled
+
+    def with_transition_gradients(self: TEnvironment) -> TEnvironment:
+        """Return a configured copy that preserves supported transition gradients."""
+        if not self.supports_transition_gradients:
+            raise ValueError(f"{self.name} does not support transition gradients")
+
+        configured_environment = copy.copy(self)
+        configured_environment._transition_gradients_enabled = True
+        return configured_environment
+
+    def _apply_transition_gradient_policy(
+        self, observation: Any, state: TEnvState
+    ) -> tuple[Any, TEnvState]:
+        """Detach transition outputs unless gradients were explicitly enabled."""
+        if self.transition_gradients_enabled:
+            return observation, state
+        return jax.tree.map(jax.lax.stop_gradient, (observation, state))
 
     @property
     def default_params(self) -> EnvParams:

--- a/gymnax/environments/misc/point_robot.py
+++ b/gymnax/environments/misc/point_robot.py
@@ -38,6 +38,8 @@ class PointRobot(environment.Environment[EnvState, EnvParams]):
     2021 https://openreview.net/pdf?id=IBdEfhLveS
     """
 
+    supports_transition_gradients = True
+
     @property
     def default_params(self) -> EnvParams:
         # Default environment parameters
@@ -72,9 +74,12 @@ class PointRobot(environment.Environment[EnvState, EnvParams]):
         )
 
         done = self.is_terminal(state, params)
+        observation, state = self._apply_transition_gradient_policy(
+            self.get_obs(state, params), state
+        )
         return (
-            jax.lax.stop_gradient(self.get_obs(state, params)),
-            jax.lax.stop_gradient(state),
+            observation,
+            state,
             reward,
             done,
             {"discount": self.discount(state, params)},

--- a/gymnax/environments/misc/point_robot.py
+++ b/gymnax/environments/misc/point_robot.py
@@ -38,7 +38,7 @@ class PointRobot(environment.Environment[EnvState, EnvParams]):
     2021 https://openreview.net/pdf?id=IBdEfhLveS
     """
 
-    supports_transition_gradients = True
+    _supports_transition_gradients = True
 
     @property
     def default_params(self) -> EnvParams:

--- a/gymnax/environments/misc/reacher.py
+++ b/gymnax/environments/misc/reacher.py
@@ -31,7 +31,7 @@ class Reacher(environment.Environment[EnvState, EnvParams]):
     Adapted from: https://github.com/unifyai/gym/blob/master/ivy_gym/reacher.py
     """
 
-    supports_transition_gradients = True
+    _supports_transition_gradients = True
 
     def __init__(self, num_joints: int = 2):
         super().__init__()

--- a/gymnax/environments/misc/reacher.py
+++ b/gymnax/environments/misc/reacher.py
@@ -31,6 +31,8 @@ class Reacher(environment.Environment[EnvState, EnvParams]):
     Adapted from: https://github.com/unifyai/gym/blob/master/ivy_gym/reacher.py
     """
 
+    supports_transition_gradients = True
+
     def __init__(self, num_joints: int = 2):
         super().__init__()
         self.num_joints = num_joints
@@ -70,9 +72,12 @@ class Reacher(environment.Environment[EnvState, EnvParams]):
         reward = reward.squeeze()
 
         done = self.is_terminal(state, params)
+        observation, state = self._apply_transition_gradient_policy(
+            self.get_obs(state, params), state
+        )
         return (
-            jax.lax.stop_gradient(self.get_obs(state, params)),
-            jax.lax.stop_gradient(state),
+            observation,
+            state,
             reward,
             done,
             {"discount": self.discount(state, params)},

--- a/gymnax/environments/misc/swimmer.py
+++ b/gymnax/environments/misc/swimmer.py
@@ -31,7 +31,7 @@ class Swimmer(environment.Environment[EnvState, EnvParams]):
     Adapted from: https://github.com/unifyai/gym/blob/master/ivy_gym/swimmer.py
     """
 
-    supports_transition_gradients = True
+    _supports_transition_gradients = True
 
     def __init__(self, num_urchins: int = 5):
         super().__init__()

--- a/gymnax/environments/misc/swimmer.py
+++ b/gymnax/environments/misc/swimmer.py
@@ -31,6 +31,8 @@ class Swimmer(environment.Environment[EnvState, EnvParams]):
     Adapted from: https://github.com/unifyai/gym/blob/master/ivy_gym/swimmer.py
     """
 
+    supports_transition_gradients = True
+
     def __init__(self, num_urchins: int = 5):
         super().__init__()
         self.num_urchins = num_urchins
@@ -67,9 +69,12 @@ class Swimmer(environment.Environment[EnvState, EnvParams]):
         )
 
         done = self.is_terminal(state, params)
+        observation, state = self._apply_transition_gradient_policy(
+            self.get_obs(state, params), state
+        )
         return (
-            jax.lax.stop_gradient(self.get_obs(state, params)),
-            jax.lax.stop_gradient(state),
+            observation,
+            state,
             reward,
             done,
             {"discount": self.discount(state, params)},

--- a/tests/test_differentiability.py
+++ b/tests/test_differentiability.py
@@ -62,6 +62,13 @@ def test_discrete_environment_rejects_transition_gradients():
         env.with_transition_gradients()
 
 
+def test_transition_gradient_capability_is_read_only():
+    env, _ = gymnax.make("CartPole-v1")
+
+    with pytest.raises(AttributeError):
+        env.supports_transition_gradients = True
+
+
 def test_default_pendulum_preserves_stopped_transition_gradients():
     env, params, state, action, key = _pendulum_fixture()
 

--- a/tests/test_differentiability.py
+++ b/tests/test_differentiability.py
@@ -1,0 +1,220 @@
+"""Tests for opt-in differentiable environment transitions."""
+
+import chex
+import jax
+import jax.numpy as jnp
+import pytest
+
+import gymnax
+from gymnax.environments.classic_control import pendulum
+from gymnax.environments.misc import point_robot
+from gymnax.wrappers import FlattenObservationWrapper
+
+SUPPORTED_ENVIRONMENTS = (
+    "Pendulum-v1",
+    "MountainCarContinuous-v0",
+    "PointRobot-misc",
+    "Reacher-misc",
+    "Swimmer-misc",
+)
+
+
+def _pendulum_fixture():
+    env, params = gymnax.make("Pendulum-v1")
+    state = pendulum.EnvState(
+        theta=jnp.array(0.5),
+        theta_dot=jnp.array(0.2),
+        last_u=jnp.array(0.0),
+        time=0,
+    )
+    action = jnp.array([0.4])
+    return env, params, state, action, jax.random.key(0)
+
+
+def _pendulum_derivatives(env, params, state, action, key):
+    observation_jacobian = jax.jacrev(
+        lambda current_action: env.step(key, state, current_action, params)[0]
+    )(action)
+    theta_dot_jacobian = jax.jacrev(
+        lambda current_action: env.step(key, state, current_action, params)[1].theta_dot
+    )(action)
+    reward_gradient = jax.grad(
+        lambda current_action: env.step(key, state, current_action, params)[2]
+    )(action)
+    return observation_jacobian, theta_dot_jacobian, reward_gradient
+
+
+def test_configured_copy_enables_supported_environment_without_mutating_original():
+    env, _ = gymnax.make("Pendulum-v1")
+
+    differentiable_env = env.with_transition_gradients()
+
+    assert differentiable_env is not env
+    assert env.supports_transition_gradients
+    assert not env.transition_gradients_enabled
+    assert differentiable_env.transition_gradients_enabled
+
+
+def test_discrete_environment_rejects_transition_gradients():
+    env, _ = gymnax.make("CartPole-v1")
+
+    with pytest.raises(ValueError, match="CartPole-v1.*transition gradients"):
+        env.with_transition_gradients()
+
+
+def test_default_pendulum_preserves_stopped_transition_gradients():
+    env, params, state, action, key = _pendulum_fixture()
+
+    observation_jacobian, theta_dot_jacobian, reward_gradient = _pendulum_derivatives(
+        env, params, state, action, key
+    )
+
+    chex.assert_trees_all_close(
+        (observation_jacobian, theta_dot_jacobian, reward_gradient),
+        (jnp.zeros((3, 1)), jnp.zeros((1,)), jnp.array([-0.0008])),
+        atol=1e-7,
+    )
+
+
+def test_opt_in_pendulum_matches_analytic_transition_gradients():
+    env, params, state, action, key = _pendulum_fixture()
+    env = env.with_transition_gradients()
+
+    observation_jacobian, theta_dot_jacobian, reward_gradient = _pendulum_derivatives(
+        env, params, state, action, key
+    )
+    next_theta = env.step(key, state, action, params)[1].theta
+    expected_observation_jacobian = jnp.array(
+        [
+            [-jnp.sin(next_theta) * 0.0075],
+            [jnp.cos(next_theta) * 0.0075],
+            [0.15],
+        ]
+    )
+
+    chex.assert_trees_all_close(
+        (observation_jacobian, theta_dot_jacobian, reward_gradient),
+        (expected_observation_jacobian, jnp.array([0.15]), jnp.array([-0.0008])),
+        atol=1e-7,
+    )
+
+
+def test_opt_in_pendulum_propagates_gradients_across_steps():
+    env, params, state, action, key = _pendulum_fixture()
+    env = env.with_transition_gradients()
+    second_action = jnp.array([0.0])
+
+    def second_reward(first_action):
+        _, next_state, _, _, _, _ = env.step(key, state, first_action, params)
+        return env.step(key, next_state, second_action, params)[2]
+
+    first_action_gradient = jax.grad(second_reward)(action)
+
+    assert jnp.any(jnp.abs(first_action_gradient) > 1e-7)
+
+
+def test_gradient_mode_does_not_change_transition_values():
+    env, params, state, action, key = _pendulum_fixture()
+
+    default_transition = env.step(key, state, action, params)
+    differentiable_transition = env.with_transition_gradients().step(
+        key, state, action, params
+    )
+
+    chex.assert_trees_all_close(default_transition, differentiable_transition)
+
+
+def test_transition_gradients_compose_with_jit_and_vmap():
+    env, params, state, _, key = _pendulum_fixture()
+    env = env.with_transition_gradients()
+    actions = jnp.array([[0.2], [0.4]])
+
+    observation_jacobian = jax.jit(
+        jax.vmap(
+            jax.jacrev(
+                lambda current_action: env.step(key, state, current_action, params)[0]
+            )
+        )
+    )(actions)
+
+    assert observation_jacobian.shape == (2, 3, 1)
+    assert jnp.all(jnp.isfinite(observation_jacobian))
+    assert jnp.all(jnp.any(jnp.abs(observation_jacobian) > 1e-7, axis=(1, 2)))
+
+
+def test_autoreset_keeps_gradient_on_final_observation():
+    env, params, state, action, key = _pendulum_fixture()
+    env = env.with_transition_gradients()
+    params = params.replace(max_steps_in_episode=1)
+
+    reset_observation_jacobian = jax.jacrev(
+        lambda current_action: env.step(key, state, current_action, params)[0]
+    )(action)
+    reset_state_jacobian = jax.jacrev(
+        lambda current_action: env.step(key, state, current_action, params)[1].theta_dot
+    )(action)
+    final_observation_jacobian = jax.jacrev(
+        lambda current_action: env.step(key, state, current_action, params)[5][
+            "final_observation"
+        ]
+    )(action)
+
+    assert jnp.all(reset_observation_jacobian == 0)
+    assert jnp.all(reset_state_jacobian == 0)
+    assert jnp.any(jnp.abs(final_observation_jacobian) > 1e-7)
+
+
+@pytest.mark.parametrize("env_name", SUPPORTED_ENVIRONMENTS)
+def test_supported_environments_expose_finite_observation_gradients(env_name):
+    env, params = gymnax.make(env_name)
+    env = env.with_transition_gradients()
+    reset_key, step_key = jax.random.split(jax.random.key(1))
+    _, state = env.reset(reset_key, params)
+    action = jnp.zeros(env.action_space(params).shape)
+
+    observation_jacobian = jax.jacrev(
+        lambda current_action: env.step_env(step_key, state, current_action, params)[0]
+    )(action)
+
+    assert env.supports_transition_gradients
+    assert jnp.all(jnp.isfinite(observation_jacobian))
+    assert jnp.any(jnp.abs(observation_jacobian) > 1e-7)
+
+
+def test_point_robot_preserves_position_dynamics_gradients_away_from_respawn():
+    env, params = gymnax.make("PointRobot-misc")
+    env = env.with_transition_gradients()
+    state = point_robot.EnvState(
+        last_action=jnp.zeros(2),
+        last_reward=jnp.array(0.0),
+        pos=jnp.zeros(2),
+        goal=jnp.array([1.0, 0.0]),
+        goals_reached=0,
+        time=0.0,
+    )
+    action = jnp.array([0.05, -0.05])
+    key = jax.random.key(2)
+
+    observation_jacobian = jax.jacrev(
+        lambda current_action: env.step_env(key, state, current_action, params)[0][:2]
+    )(action)
+    position_jacobian = jax.jacrev(
+        lambda current_action: env.step_env(key, state, current_action, params)[1].pos
+    )(action)
+
+    assert jnp.linalg.norm(state.goal - state.pos) > params.goal_radius
+    chex.assert_trees_all_close(
+        (observation_jacobian, position_jacobian),
+        (jnp.eye(2), jnp.eye(2)),
+    )
+
+
+def test_configured_environment_composes_with_observation_wrapper():
+    env, params, state, action, key = _pendulum_fixture()
+    wrapped_env = FlattenObservationWrapper(env.with_transition_gradients())
+
+    observation_jacobian = jax.jacrev(
+        lambda current_action: wrapped_env.step(key, state, current_action, params)[0]
+    )(action)
+
+    assert jnp.any(jnp.abs(observation_jacobian) > 1e-7)


### PR DESCRIPTION
## What changed

- add `Environment.with_transition_gradients()` as a non-mutating configured-copy API
- preserve default stop-gradient behavior and reject unsupported environments
- support Pendulum, Continuous Mountain Car, PointRobot, Reacher, and Swimmer
- document pathwise-gradient, clipping, autoreset, and `final_observation` semantics
- add analytic, multi-step, JIT/vmap, wrapper, capability, and autoreset coverage

## Why

Continuous-control and model-based users need to differentiate through transition observations and state while standard model-free pipelines must retain the existing detached default. The opt-in is explicit and creates a new environment identity so JIT caching remains safe.

Gradients are local/pathwise derivatives of the executed JAX program. Discrete events, clipping boundaries, termination decisions, and PointRobot respawns remain nonsmooth. CartPole and other discrete-action environments are intentionally unsupported.

Closes #26

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- full test matrix: 188 passed, 3 skipped; 92% coverage
- JAX x64 regressions: 2 passed
- `uv build`
- pre-push review swarm: no remaining material findings